### PR TITLE
Improve CLI sandbox startup and transport reliability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,6 +1530,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "rustix 0.38.44",
  "sandbox-config",
  "sandbox-observability-query",
  "sandbox-observability-telemetry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +316,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +474,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1027,6 +1052,16 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1663,6 +1698,7 @@ version = "0.1.0"
 dependencies = [
  "bollard",
  "bytes",
+ "flate2",
  "futures-util",
  "http-body-util",
  "hyper",
@@ -1977,6 +2013,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ clap = { version = "4", features = ["derive", "env"] }
 proptest = "1"
 base64 = "0.22"
 futures-util = "0.3"
+flate2 = "1"
 rtnetlink = "0.21"
 netlink-sys = "0.8"
 bollard = "0.17"

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ The UI lives in the separate
 [Ephemeral Sandbox Console](https://github.com/Ephemeral-AI-Lab/ephemeral-sandbox-console)
 repository. Start the gateway above, then point the console at:
 
-- socket: `127.0.0.1:7878`
+- Windows CLI/MCP endpoint: `npipe://./pipe/ephemeral-sandbox-gateway`
+- console socket after explicitly starting the gateway on TCP: `127.0.0.1:7878`
 - Linux/macOS token: `$HOME/.ephemeral-sandbox/gateway.token`
 - Windows token: `$HOME\.ephemeral-sandbox\gateway.token`
 

--- a/bin/package-windows-amd64-release.ps1
+++ b/bin/package-windows-amd64-release.ps1
@@ -104,7 +104,7 @@ Use the gateway from another PowerShell window:
 ```powershell
 $env:SANDBOX_GATEWAY_AUTH_TOKEN = Get-Content "$HOME\.ephemeral-sandbox\gateway.token"
 $env:SANDBOX_IMAGE = "alpine:3.20"
-.\bin\sandbox-manager-cli.exe --gateway-socket 127.0.0.1:7878 --gateway-auth-token $env:SANDBOX_GATEWAY_AUTH_TOKEN list_docker_images
+.\bin\sandbox-manager-cli.exe --gateway-endpoint npipe://./pipe/ephemeral-sandbox-gateway --gateway-auth-token $env:SANDBOX_GATEWAY_AUTH_TOKEN list_docker_images
 ```
 '@ | Set-Content -LiteralPath (Join-Path $stageDir "INSTALL.md") -Encoding UTF8
 

--- a/bin/start-sandbox-windows-docker-gateway.ps1
+++ b/bin/start-sandbox-windows-docker-gateway.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string]$GatewaySocket = $(if ($env:SANDBOX_GATEWAY_SOCKET) { $env:SANDBOX_GATEWAY_SOCKET } else { "127.0.0.1:7878" }),
+    [string]$GatewaySocket = $(if ($env:SANDBOX_GATEWAY_SOCKET) { $env:SANDBOX_GATEWAY_SOCKET } else { "npipe://./pipe/ephemeral-sandbox-gateway" }),
     [string]$ConfigYaml = $(if ($env:SANDBOX_GATEWAY_CONFIG_YAML) { $env:SANDBOX_GATEWAY_CONFIG_YAML } else { "" }),
     [string]$PidFile = $(if ($env:SANDBOX_GATEWAY_PID_FILE) { $env:SANDBOX_GATEWAY_PID_FILE } else { Join-Path $env:TEMP "eos-gateway-windows.pid" }),
     [string]$LogPath = $(if ($env:SANDBOX_GATEWAY_LOG) { $env:SANDBOX_GATEWAY_LOG } else { Join-Path $env:TEMP "eos-gateway-windows.log" })
@@ -100,7 +100,7 @@ $gatewayArgs = @(
     "serve",
     "--backend", "docker",
     "--config-yaml", $ConfigYaml,
-    "--gateway-socket", $GatewaySocket,
+    "--gateway-endpoint", $GatewaySocket,
     "--auth-token", $authToken,
     "--pid-file", $PidFile
 )
@@ -130,7 +130,7 @@ for ($i = 0; $i -lt 30; $i++) {
 
 Write-Host "sandbox-gateway starting in background via pid $($process.Id)"
 Write-Host "pid file: $PidFile"
-Write-Host "address: $GatewaySocket"
+Write-Host "endpoint: $GatewaySocket"
 Write-Host "auth token file: $tokenPath"
 Write-Host "log: $LogPath"
 Write-Host "error log: $errorLogPath"

--- a/config/windows-amd64.yml
+++ b/config/windows-amd64.yml
@@ -30,7 +30,7 @@ runner:
 observability:
   resource_stats:
     enabled: true
-    sample_interval_ms: 250
+    sample_interval_ms: 100
     max_disk_bytes: 1048576
 
 manager:

--- a/config/windows-amd64.yml
+++ b/config/windows-amd64.yml
@@ -27,6 +27,12 @@ runner:
     hidden_paths:
       - /eos
 
+observability:
+  resource_stats:
+    enabled: true
+    sample_interval_ms: 250
+    max_disk_bytes: 1048576
+
 manager:
   docker:
     privileged: false

--- a/crates/sandbox-cli/src/bin/sandbox-manager-cli.rs
+++ b/crates/sandbox-cli/src/bin/sandbox-manager-cli.rs
@@ -1,6 +1,6 @@
 use std::process::ExitCode;
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> ExitCode {
     sandbox_cli::manager::run_cli(std::env::args_os()).await
 }

--- a/crates/sandbox-cli/src/bin/sandbox-observability-cli.rs
+++ b/crates/sandbox-cli/src/bin/sandbox-observability-cli.rs
@@ -1,6 +1,6 @@
 use std::process::ExitCode;
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> ExitCode {
     sandbox_cli::observability::run_cli(std::env::args_os()).await
 }

--- a/crates/sandbox-cli/src/bin/sandbox-runtime-cli.rs
+++ b/crates/sandbox-cli/src/bin/sandbox-runtime-cli.rs
@@ -1,6 +1,6 @@
 use std::process::ExitCode;
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> ExitCode {
     sandbox_cli::runtime::run_cli(std::env::args_os()).await
 }

--- a/crates/sandbox-cli/src/help.rs
+++ b/crates/sandbox-cli/src/help.rs
@@ -194,6 +194,13 @@ fn push_argument(output: &mut String, arg: &ArgSpecDocument, cli: Option<&Argume
     if let Some(default) = &arg.default {
         push_indented_line(output, 4, &format!("Default: {default}"));
     }
+    if let Some(value_file_flag) = cli.and_then(|cli| cli.value_file_flag) {
+        push_indented_line(
+            output,
+            4,
+            &format!("Alternatively, {value_file_flag} FILE reads the value as UTF-8."),
+        );
+    }
     output.push('\n');
 }
 

--- a/crates/sandbox-cli/src/input.rs
+++ b/crates/sandbox-cli/src/input.rs
@@ -1,8 +1,11 @@
 //! CLI-owned argv projection and request input construction.
 
+use std::fs::File;
+use std::io::Read;
+
 use sandbox_operation_client::{
     build_request_from_values, build_request_from_values_with_id, BuildRequestValueInput,
-    RequestBuildError,
+    RequestBuildError, MAX_REQUEST_BYTES,
 };
 use sandbox_operation_contract::{
     operation_domain_name, ArgKind, ArgSpecDocument, OperationCatalogDocument, OperationDomain,
@@ -192,7 +195,8 @@ fn build_args(
             let value = argv
                 .get(index)
                 .ok_or_else(|| build_error(format!("{token} requires a value")))?;
-            insert_arg_value(&mut values, arg, projected_arg, value)?;
+            let value = read_projected_value(projected_arg, token, value)?;
+            insert_arg_value(&mut values, arg, projected_arg, &value)?;
         } else {
             let projected_arg = positional_args.get(next_positional).ok_or_else(|| {
                 build_error(format!(
@@ -209,6 +213,37 @@ fn build_args(
 
     require_cli_args(spec, projection, &values)?;
     Ok(Value::Object(values))
+}
+
+fn read_projected_value(
+    projection: &ArgumentProjection,
+    flag: &str,
+    value: &str,
+) -> Result<String, RequestBuildError> {
+    if projection.value_file_flag != Some(flag) {
+        return Ok(value.to_owned());
+    }
+    let file = File::open(value)
+        .map_err(|error| build_error(format!("{flag} could not read {value}: {error}")))?;
+    let length = file
+        .metadata()
+        .map_err(|error| build_error(format!("{flag} could not inspect {value}: {error}")))?
+        .len();
+    if length > MAX_REQUEST_BYTES as u64 {
+        return Err(build_error(format!(
+            "{flag} exceeds the {MAX_REQUEST_BYTES}-byte gateway request limit"
+        )));
+    }
+    let mut bytes = Vec::new();
+    file.take(MAX_REQUEST_BYTES as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| build_error(format!("{flag} could not read {value}: {error}")))?;
+    if bytes.len() > MAX_REQUEST_BYTES {
+        return Err(build_error(format!(
+            "{flag} exceeds the {MAX_REQUEST_BYTES}-byte gateway request limit"
+        )));
+    }
+    String::from_utf8(bytes).map_err(|_| build_error(format!("{flag} must contain valid UTF-8")))
 }
 
 fn require_cli_args(

--- a/crates/sandbox-cli/src/input.rs
+++ b/crates/sandbox-cli/src/input.rs
@@ -16,6 +16,9 @@ use serde_json::{Map, Number, Value};
 use crate::projection::document::{operation_projection, CatalogDocument};
 use crate::projection::{ArgumentProjection, OperationProjection};
 
+pub const REQUEST_ID_ERROR: &str =
+    "--request-id must be 1-128 ASCII letters, digits, period, underscore, colon, or dash";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BuildRequestInput {
     pub execution_space: OperationDomain,
@@ -213,6 +216,23 @@ fn build_args(
 
     require_cli_args(spec, projection, &values)?;
     Ok(Value::Object(values))
+}
+
+pub fn validate_request_id(
+    request_id: Option<String>,
+) -> Result<Option<String>, RequestBuildError> {
+    let Some(request_id) = request_id else {
+        return Ok(None);
+    };
+    if request_id.len() > 128
+        || request_id.is_empty()
+        || !request_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || b"._:-".contains(&byte))
+    {
+        return Err(RequestBuildError::invalid(REQUEST_ID_ERROR));
+    }
+    Ok(Some(request_id))
 }
 
 fn read_projected_value(

--- a/crates/sandbox-cli/src/manager.rs
+++ b/crates/sandbox-cli/src/manager.rs
@@ -12,16 +12,16 @@ use std::process::ExitCode;
 use clap::error::ErrorKind;
 use clap::Parser;
 
-use crate::input::BuildRequestInput;
+use crate::input::{validate_request_id, BuildRequestInput};
 use crate::output::{
     discover_config, render_error, render_help_command, render_request_error,
-    run_request_from_catalog, take_progress_flag, EXIT_SUCCESS, EXIT_USAGE,
+    run_request_from_catalog_with_id, take_progress_flag, EXIT_SUCCESS, EXIT_USAGE,
 };
 use crate::projection::document::{catalog_document, CatalogDocument};
 use sandbox_operation_client::{GatewayClient, GatewayConfigOverrides, RequestBuildError};
 use sandbox_operation_contract::OperationDomain;
 
-const PROGRAM: &str = "sandbox-manager-cli";
+const PROGRAM: &str = "sandbox-manager-cli [--request-id VALUE]";
 const HELP_OP: &str = "help";
 const CREATE_SANDBOX_OP: &str = "create_sandbox";
 
@@ -36,6 +36,14 @@ struct Cli {
 
     #[arg(long = "progress", global = true)]
     progress: bool,
+
+    #[arg(
+        long = "request-id",
+        value_name = "VALUE",
+        global = true,
+        allow_hyphen_values = true
+    )]
+    request_id: Option<String>,
 
     operation: Option<String>,
 
@@ -78,6 +86,13 @@ where
             return EXIT_USAGE;
         }
     };
+    let request_id = match validate_request_id(cli.request_id) {
+        Ok(request_id) => request_id,
+        Err(error) => {
+            let _ = render_request_error(&error, stderr);
+            return EXIT_USAGE;
+        }
+    };
 
     let overrides = GatewayConfigOverrides {
         gateway_socket_path: cli.gateway_socket_path,
@@ -97,6 +112,7 @@ where
         cli.operation_argv,
         overrides,
         global_progress,
+        request_id,
         stdout,
         stderr,
     )
@@ -108,6 +124,7 @@ async fn run_manager<WOut, WErr>(
     mut operation_argv: Vec<String>,
     overrides: GatewayConfigOverrides,
     global_progress: bool,
+    request_id: Option<String>,
     stdout: &mut WOut,
     stderr: &mut WErr,
 ) -> u8
@@ -133,7 +150,16 @@ where
         operation_argv,
         sandbox_id: None,
     };
-    run_request_from_catalog(&client, request_input, &catalog, progress, stdout, stderr).await
+    run_request_from_catalog_with_id(
+        &client,
+        request_input,
+        request_id,
+        &catalog,
+        progress,
+        stdout,
+        stderr,
+    )
+    .await
 }
 
 fn manager_catalog<WErr>(stderr: &mut WErr) -> Result<CatalogDocument, u8>

--- a/crates/sandbox-cli/src/manager.rs
+++ b/crates/sandbox-cli/src/manager.rs
@@ -28,7 +28,12 @@ const CREATE_SANDBOX_OP: &str = "create_sandbox";
 #[derive(Debug, Parser)]
 #[command(name = "sandbox-manager-cli", disable_help_subcommand = true)]
 struct Cli {
-    #[arg(long = "gateway-socket", value_name = "HOST:PORT", global = true)]
+    #[arg(
+        long = "gateway-endpoint",
+        visible_alias = "gateway-socket",
+        value_name = "URI",
+        global = true
+    )]
     gateway_socket_path: Option<PathBuf>,
 
     #[arg(long = "gateway-auth-token", value_name = "TOKEN", global = true)]
@@ -194,8 +199,8 @@ where
     WErr: Write,
 {
     let config = discover_config(overrides, stderr).ok()?;
-    Some(GatewayClient::new(
-        config.gateway_socket_path.to_string_lossy().into_owned(),
-        config.gateway_auth_token.clone(),
+    Some(GatewayClient::from_endpoint(
+        config.gateway_endpoint,
+        config.gateway_auth_token,
     ))
 }

--- a/crates/sandbox-cli/src/observability.rs
+++ b/crates/sandbox-cli/src/observability.rs
@@ -9,16 +9,16 @@ use std::process::ExitCode;
 use clap::error::ErrorKind;
 use clap::Parser;
 
-use crate::input::BuildRequestInput;
+use crate::input::{validate_request_id, BuildRequestInput};
 use crate::output::{
     discover_config, render_error, render_help_command, render_request_error,
-    run_request_from_catalog, EXIT_SUCCESS, EXIT_USAGE,
+    run_request_from_catalog_with_id, EXIT_SUCCESS, EXIT_USAGE,
 };
 use crate::projection::document::catalog_document;
 use sandbox_operation_client::{GatewayClient, GatewayConfigOverrides, RequestBuildError};
 use sandbox_operation_contract::OperationDomain;
 
-const PROGRAM: &str = "sandbox-observability-cli";
+const PROGRAM: &str = "sandbox-observability-cli [--request-id VALUE]";
 const HELP_OP: &str = "help";
 
 #[derive(Debug, Parser)]
@@ -29,6 +29,14 @@ struct Cli {
 
     #[arg(long = "gateway-auth-token", value_name = "TOKEN", global = true)]
     gateway_auth_token: Option<String>,
+
+    #[arg(
+        long = "request-id",
+        value_name = "VALUE",
+        global = true,
+        allow_hyphen_values = true
+    )]
+    request_id: Option<String>,
 
     operation: Option<String>,
 
@@ -71,6 +79,13 @@ where
             return EXIT_USAGE;
         }
     };
+    let request_id = match validate_request_id(cli.request_id) {
+        Ok(request_id) => request_id,
+        Err(error) => {
+            let _ = render_request_error(&error, stderr);
+            return EXIT_USAGE;
+        }
+    };
 
     let catalog = match catalog_document(
         sandbox_operation_catalog::observability::observability_catalog(),
@@ -104,7 +119,16 @@ where
         operation_argv: cli.operation_argv,
         sandbox_id: None,
     };
-    run_request_from_catalog(&client, request_input, &catalog, false, stdout, stderr).await
+    run_request_from_catalog_with_id(
+        &client,
+        request_input,
+        request_id,
+        &catalog,
+        false,
+        stdout,
+        stderr,
+    )
+    .await
 }
 
 fn client_from<WErr>(overrides: GatewayConfigOverrides, stderr: &mut WErr) -> Option<GatewayClient>

--- a/crates/sandbox-cli/src/observability.rs
+++ b/crates/sandbox-cli/src/observability.rs
@@ -24,7 +24,12 @@ const HELP_OP: &str = "help";
 #[derive(Debug, Parser)]
 #[command(name = "sandbox-observability-cli", disable_help_subcommand = true)]
 struct Cli {
-    #[arg(long = "gateway-socket", value_name = "HOST:PORT", global = true)]
+    #[arg(
+        long = "gateway-endpoint",
+        visible_alias = "gateway-socket",
+        value_name = "URI",
+        global = true
+    )]
     gateway_socket_path: Option<PathBuf>,
 
     #[arg(long = "gateway-auth-token", value_name = "TOKEN", global = true)]
@@ -136,8 +141,8 @@ where
     WErr: Write,
 {
     let config = discover_config(overrides, stderr).ok()?;
-    Some(GatewayClient::new(
-        config.gateway_socket_path.to_string_lossy().into_owned(),
-        config.gateway_auth_token.clone(),
+    Some(GatewayClient::from_endpoint(
+        config.gateway_endpoint,
+        config.gateway_auth_token,
     ))
 }

--- a/crates/sandbox-cli/src/projection/mod.rs
+++ b/crates/sandbox-cli/src/projection/mod.rs
@@ -14,6 +14,7 @@ pub struct ArgumentProjection {
     pub name: &'static str,
     pub flag: Option<&'static str>,
     pub additional_flags: &'static [&'static str],
+    pub value_file_flag: Option<&'static str>,
     pub positional: Option<&'static str>,
 }
 
@@ -24,6 +25,22 @@ impl ArgumentProjection {
             name,
             flag: Some(flag),
             additional_flags: &[],
+            value_file_flag: None,
+            positional: None,
+        }
+    }
+
+    #[must_use]
+    pub const fn flag_with_value_file(
+        name: &'static str,
+        flag: &'static str,
+        value_file_flag: &'static str,
+    ) -> Self {
+        Self {
+            name,
+            flag: Some(flag),
+            additional_flags: &[],
+            value_file_flag: Some(value_file_flag),
             positional: None,
         }
     }
@@ -38,6 +55,7 @@ impl ArgumentProjection {
             name,
             flag: Some(flag),
             additional_flags,
+            value_file_flag: None,
             positional: None,
         }
     }
@@ -48,13 +66,16 @@ impl ArgumentProjection {
             name,
             flag: None,
             additional_flags: &[],
+            value_file_flag: None,
             positional: Some(positional),
         }
     }
 
     #[must_use]
     pub fn accepts_flag(&self, flag: &str) -> bool {
-        self.flag == Some(flag) || self.additional_flags.contains(&flag)
+        self.flag == Some(flag)
+            || self.additional_flags.contains(&flag)
+            || self.value_file_flag == Some(flag)
     }
 }
 

--- a/crates/sandbox-cli/src/projection/runtime.rs
+++ b/crates/sandbox-cli/src/projection/runtime.rs
@@ -30,7 +30,7 @@ const FILE_READ_ARGUMENTS: &[ArgumentProjection] = &[
 
 const FILE_WRITE_ARGUMENTS: &[ArgumentProjection] = &[
     ArgumentProjection::flag("path", "--path"),
-    ArgumentProjection::flag("content", "--content"),
+    ArgumentProjection::flag_with_value_file("content", "--content", "--content-file"),
     ArgumentProjection::flag("workspace_session_id", "--workspace-session-id"),
 ];
 

--- a/crates/sandbox-cli/src/runtime.rs
+++ b/crates/sandbox-cli/src/runtime.rs
@@ -29,7 +29,12 @@ const HELP_OP: &str = "help";
 #[derive(Debug, Parser)]
 #[command(name = "sandbox-runtime-cli", disable_help_subcommand = true)]
 struct Cli {
-    #[arg(long = "gateway-socket", value_name = "HOST:PORT", global = true)]
+    #[arg(
+        long = "gateway-endpoint",
+        visible_alias = "gateway-socket",
+        value_name = "URI",
+        global = true
+    )]
     gateway_socket_path: Option<PathBuf>,
 
     #[arg(long = "gateway-auth-token", value_name = "TOKEN", global = true)]
@@ -151,8 +156,8 @@ where
     WErr: Write,
 {
     let config = discover_config(overrides, stderr).ok()?;
-    Some(GatewayClient::new(
-        config.gateway_socket_path.to_string_lossy().into_owned(),
-        config.gateway_auth_token.clone(),
+    Some(GatewayClient::from_endpoint(
+        config.gateway_endpoint,
+        config.gateway_auth_token,
     ))
 }

--- a/crates/sandbox-cli/src/runtime.rs
+++ b/crates/sandbox-cli/src/runtime.rs
@@ -14,7 +14,7 @@ use std::process::ExitCode;
 use clap::error::ErrorKind;
 use clap::Parser;
 
-use crate::input::{resolve_runtime_sandbox_id, BuildRequestInput};
+use crate::input::{resolve_runtime_sandbox_id, validate_request_id, BuildRequestInput};
 use crate::output::{
     discover_config, render_error, render_help_command, render_request_error,
     run_request_from_catalog_with_id, EXIT_SUCCESS, EXIT_USAGE,
@@ -25,8 +25,6 @@ use sandbox_operation_contract::OperationDomain;
 
 const PROGRAM: &str = "sandbox-runtime-cli --sandbox-id ID [--request-id VALUE]";
 const HELP_OP: &str = "help";
-const REQUEST_ID_ERROR: &str =
-    "--request-id must be 1-128 ASCII letters, digits, period, underscore, colon, or dash";
 
 #[derive(Debug, Parser)]
 #[command(name = "sandbox-runtime-cli", disable_help_subcommand = true)]
@@ -146,21 +144,6 @@ where
         stderr,
     )
     .await
-}
-
-fn validate_request_id(request_id: Option<String>) -> Result<Option<String>, RequestBuildError> {
-    let Some(request_id) = request_id else {
-        return Ok(None);
-    };
-    if request_id.len() > 128
-        || request_id.is_empty()
-        || !request_id
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || b"._:-".contains(&byte))
-    {
-        return Err(RequestBuildError::invalid(REQUEST_ID_ERROR));
-    }
-    Ok(Some(request_id))
 }
 
 fn client_from<WErr>(overrides: GatewayConfigOverrides, stderr: &mut WErr) -> Option<GatewayClient>

--- a/crates/sandbox-cli/tests/compatibility.rs
+++ b/crates/sandbox-cli/tests/compatibility.rs
@@ -115,10 +115,8 @@ fn unknown_operation_errors_and_exit_codes_match_phase_zero_fixture() {
         .map(|(name, binary, argv)| invocation(name, binary, argv))
         .collect::<Vec<_>>();
 
-    assert_eq!(
-        format!("{}\n", Value::Array(actual)),
-        include_str!("fixtures/unknown-operation-errors.json")
-    );
+    let expected = include_str!("fixtures/unknown-operation-errors.json").replace("\r\n", "\n");
+    assert_eq!(format!("{}\n", Value::Array(actual)), expected);
 }
 
 fn invocation(name: &str, binary: &str, argv: &[&str]) -> Value {

--- a/crates/sandbox-cli/tests/fixtures/manager-help.txt
+++ b/crates/sandbox-cli/tests/fixtures/manager-help.txt
@@ -28,4 +28,4 @@ Management
     Export a sandbox's published changes to a host path.
 
 Use:
-  sandbox-manager-cli OPERATION
+  sandbox-manager-cli [--request-id VALUE] OPERATION

--- a/crates/sandbox-cli/tests/fixtures/observability-help.txt
+++ b/crates/sandbox-cli/tests/fixtures/observability-help.txt
@@ -19,10 +19,10 @@ Events
     List domain-fact events across traces.
 
 Resources
-  Inspect manager-owned resource metrics.
+  Inspect bounded resource metrics.
 
   resources
-    Read manager-owned sandbox resource metrics.
+    Read bounded sandbox or fleet resource metrics.
 
 Daemon
   Inspect daemon self-metrics.

--- a/crates/sandbox-cli/tests/fixtures/observability-help.txt
+++ b/crates/sandbox-cli/tests/fixtures/observability-help.txt
@@ -55,4 +55,4 @@ Resource efficiency
   Qualify sandbox resource efficiency.
 
 Use:
-  sandbox-observability-cli OPERATION
+  sandbox-observability-cli [--request-id VALUE] OPERATION

--- a/crates/sandbox-cli/tests/manager.rs
+++ b/crates/sandbox-cli/tests/manager.rs
@@ -188,6 +188,26 @@ async fn omitted_create_count_uses_catalog_default() {
 }
 
 #[tokio::test]
+async fn explicit_gateway_endpoint_accepts_a_typed_tcp_uri() {
+    let response = json!({"sandboxes": []});
+    let (addr, received) = fake_gateway(response.clone()).await;
+    let endpoint = format!("tcp://{addr}");
+    let (code, stdout, stderr) = run(&[
+        "sandbox-manager-cli",
+        "--gateway-endpoint",
+        &endpoint,
+        "list_sandboxes",
+    ])
+    .await;
+
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+    assert_eq!(parse_json_line(&stdout), response);
+    let request = received.await.expect("fake gateway task");
+    assert_eq!(request["op"], "list_sandboxes");
+}
+
+#[tokio::test]
 async fn progress_streams_to_stderr_and_keeps_final_json_on_stdout() {
     let response = json!({"sandboxes": []});
     let raw_response = format!("cli_log(\"manager fixture progress\")\n{response}\n").into_bytes();

--- a/crates/sandbox-cli/tests/manager.rs
+++ b/crates/sandbox-cli/tests/manager.rs
@@ -65,7 +65,7 @@ async fn help_lists_exact_management_catalog() {
             "export_changes",
         ]
     );
-    assert!(stdout.contains("Use:\n  sandbox-manager-cli OPERATION"));
+    assert!(stdout.contains("Use:\n  sandbox-manager-cli [--request-id VALUE] OPERATION"));
 }
 
 #[tokio::test]
@@ -89,7 +89,7 @@ async fn bare_invocation_prints_manager_catalog_help() {
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
     assert!(stdout.contains("Sandbox Manager Help"));
-    assert!(stdout.contains("Use:\n  sandbox-manager-cli OPERATION"));
+    assert!(stdout.contains("Use:\n  sandbox-manager-cli [--request-id VALUE] OPERATION"));
 }
 
 #[tokio::test]
@@ -279,6 +279,27 @@ async fn success_is_one_stdout_json_line_and_uses_system_scope() {
     assert!(request["request_id"]
         .as_str()
         .is_some_and(|id| !id.is_empty()));
+}
+
+#[tokio::test]
+async fn explicit_request_id_is_forwarded_unchanged() {
+    let response = json!({"sandboxes": []});
+    let (addr, received) = fake_gateway(response).await;
+    let (code, stdout, stderr) = run(&[
+        "sandbox-manager-cli",
+        "--gateway-socket",
+        &addr,
+        "--request-id",
+        "exp1.manager.ready.001",
+        "list_sandboxes",
+    ])
+    .await;
+
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+    assert_eq!(parse_json_line(&stdout), json!({"sandboxes": []}));
+    let request = received.await.expect("fake gateway task");
+    assert_eq!(request["request_id"], "exp1.manager.ready.001");
 }
 
 #[tokio::test]

--- a/crates/sandbox-cli/tests/manager.rs
+++ b/crates/sandbox-cli/tests/manager.rs
@@ -48,7 +48,10 @@ async fn help_lists_exact_management_catalog() {
     let (code, stdout, stderr) = run(&["sandbox-manager-cli", "help"]).await;
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
-    assert_eq!(stdout, include_str!("fixtures/manager-help.txt"));
+    assert_eq!(
+        stdout,
+        include_str!("fixtures/manager-help.txt").replace("\r\n", "\n")
+    );
     assert_eq!(
         help_operation_names(&stdout),
         [

--- a/crates/sandbox-cli/tests/observability.rs
+++ b/crates/sandbox-cli/tests/observability.rs
@@ -42,7 +42,7 @@ async fn help_lists_exact_observability_catalog() {
             "layerstack"
         ]
     );
-    assert!(stdout.contains("Use:\n  sandbox-observability-cli OPERATION"));
+    assert!(stdout.contains("Use:\n  sandbox-observability-cli [--request-id VALUE] OPERATION"));
 }
 
 #[tokio::test]
@@ -81,6 +81,27 @@ async fn aggregate_snapshot_uses_system_scope() {
     assert_eq!(request["scope"], json!({"kind": "system"}));
     assert_eq!(request["args"], json!({}));
     assert_eq!(request["_stream_logs"], false);
+}
+
+#[tokio::test]
+async fn explicit_request_id_is_forwarded_unchanged() {
+    let response = json!({"sandboxes": []});
+    let (addr, received) = fake_gateway(response).await;
+    let (code, stdout, stderr) = run(&[
+        "sandbox-observability-cli",
+        "--gateway-socket",
+        &addr,
+        "--request-id",
+        "exp1.observability.snapshot.001",
+        "snapshot",
+    ])
+    .await;
+
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+    assert_eq!(parse_json_line(&stdout), json!({"sandboxes": []}));
+    let request = received.await.expect("fake gateway task");
+    assert_eq!(request["request_id"], "exp1.observability.snapshot.001");
 }
 
 #[tokio::test]

--- a/crates/sandbox-cli/tests/observability.rs
+++ b/crates/sandbox-cli/tests/observability.rs
@@ -25,7 +25,10 @@ async fn help_lists_exact_observability_catalog() {
     let (code, stdout, stderr) = run(&["sandbox-observability-cli", "help"]).await;
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
-    assert_eq!(stdout, include_str!("fixtures/observability-help.txt"));
+    assert_eq!(
+        stdout,
+        include_str!("fixtures/observability-help.txt").replace("\r\n", "\n")
+    );
     assert_eq!(
         help_operation_names(&stdout),
         [

--- a/crates/sandbox-cli/tests/projection_integrity.rs
+++ b/crates/sandbox-cli/tests/projection_integrity.rs
@@ -102,6 +102,13 @@ fn assert_unique_argument_bindings(operation: &sandbox_cli::projection::Operatio
                 operation.name
             );
         }
+        if let Some(flag) = argument.value_file_flag {
+            assert!(
+                flags.insert(flag),
+                "duplicate flag in {}: {flag}",
+                operation.name
+            );
+        }
         if let Some(positional) = argument.positional {
             assert!(
                 positionals.insert(positional),

--- a/crates/sandbox-cli/tests/runtime.rs
+++ b/crates/sandbox-cli/tests/runtime.rs
@@ -2,12 +2,23 @@
 
 mod support;
 
+use std::fs;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use sandbox_cli::runtime::run_cli_with_writers;
 use serde_json::json;
 use support::{fake_gateway, help_operation_names, parse_json_line};
 use tokio::net::TcpListener;
+
+fn temp_file(label: &str) -> std::path::PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    std::env::temp_dir().join(format!(
+        "sandbox-cli-{label}-{}-{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    ))
+}
 
 async fn run(args: &[&str]) -> (u8, String, String) {
     let mut stdout = Vec::new();
@@ -26,7 +37,10 @@ async fn help_lists_exact_runtime_catalog() {
         run(&["sandbox-runtime-cli", "--sandbox-id", "eos-x", "help"]).await;
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
-    assert_eq!(stdout, include_str!("fixtures/runtime-help.txt"));
+    assert_eq!(
+        stdout,
+        include_str!("fixtures/runtime-help.txt").replace("\r\n", "\n")
+    );
     assert_eq!(
         help_operation_names(&stdout),
         [
@@ -99,6 +113,12 @@ async fn operation_help_uses_runtime_program_name() {
     ));
     assert!(stdout.contains("--workspace-session-id string required"));
     assert!(stdout.contains("--grace-s float optional"));
+
+    let (code, stdout, stderr) = run(&["sandbox-runtime-cli", "help", "file_write"]).await;
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+    assert!(stdout.contains("--content string required"));
+    assert!(stdout.contains("Alternatively, --content-file FILE reads the value as UTF-8."));
 }
 
 #[tokio::test]
@@ -424,6 +444,95 @@ async fn omitted_read_arguments_use_catalog_defaults() {
         request["args"],
         json!({"path": "README.md", "offset": 1, "limit": 2000})
     );
+}
+
+#[tokio::test]
+async fn file_write_reads_large_utf8_content_from_file_after_process_start() {
+    let content = "x".repeat(256 * 1024);
+    let content_path = temp_file("content");
+    fs::write(&content_path, &content).expect("write content fixture");
+    let content_path = content_path.to_string_lossy().into_owned();
+    let response = json!({"path": "large.txt", "bytes_written": content.len()});
+    let (addr, received) = fake_gateway(response.clone()).await;
+    let (code, stdout, stderr) = run(&[
+        "sandbox-runtime-cli",
+        "--gateway-socket",
+        &addr,
+        "--sandbox-id",
+        "eos-x",
+        "file_write",
+        "--path",
+        "large.txt",
+        "--content-file",
+        &content_path,
+    ])
+    .await;
+    fs::remove_file(&content_path).expect("remove content fixture");
+
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+    assert_eq!(parse_json_line(&stdout), response);
+    let request = received.await.expect("fake gateway task");
+    assert_eq!(request["op"], "file_write");
+    assert_eq!(request["args"]["path"], "large.txt");
+    assert_eq!(
+        request["args"]["content"]
+            .as_str()
+            .expect("content string")
+            .len(),
+        256 * 1024
+    );
+}
+
+#[tokio::test]
+async fn file_write_rejects_duplicate_and_non_utf8_content_sources() {
+    let invalid_path = temp_file("invalid-utf8");
+    fs::write(&invalid_path, [0xff, 0xfe]).expect("write invalid UTF-8 fixture");
+    let invalid_path = invalid_path.to_string_lossy().into_owned();
+
+    let (code, stdout, stderr) = run(&[
+        "sandbox-runtime-cli",
+        "--gateway-socket",
+        "127.0.0.1:1",
+        "--sandbox-id",
+        "eos-x",
+        "file_write",
+        "--path",
+        "notes.txt",
+        "--content-file",
+        &invalid_path,
+    ])
+    .await;
+    assert_eq!(code, 2);
+    assert!(stdout.is_empty());
+    assert!(parse_json_line(&stderr)["error"]["message"]
+        .as_str()
+        .expect("error message")
+        .contains("--content-file must contain valid UTF-8"));
+
+    fs::write(&invalid_path, "from-file").expect("replace content fixture");
+    let (code, stdout, stderr) = run(&[
+        "sandbox-runtime-cli",
+        "--gateway-socket",
+        "127.0.0.1:1",
+        "--sandbox-id",
+        "eos-x",
+        "file_write",
+        "--path",
+        "notes.txt",
+        "--content",
+        "inline",
+        "--content-file",
+        &invalid_path,
+    ])
+    .await;
+    fs::remove_file(&invalid_path).expect("remove content fixture");
+    assert_eq!(code, 2);
+    assert!(stdout.is_empty());
+    assert!(parse_json_line(&stderr)["error"]["message"]
+        .as_str()
+        .expect("error message")
+        .contains("--content was provided more than once"));
 }
 
 #[tokio::test]

--- a/crates/sandbox-config/src/configs/gateway.rs
+++ b/crates/sandbox-config/src/configs/gateway.rs
@@ -1,19 +1,89 @@
 //! Typed schema for the optional `gateway` section of the sandbox config,
 //! doubling as the gateway server's runtime config.
 
+use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use serde::Deserialize;
+use thiserror::Error;
 
-use crate::configs::validate::{
-    require_non_empty, require_socket_addr, require_usize_at_least, ConfigFieldError,
-};
+use crate::configs::validate::{require_non_empty, require_usize_at_least, ConfigFieldError};
 
+#[cfg(windows)]
+pub const DEFAULT_GATEWAY_SOCKET: &str = "npipe://./pipe/ephemeral-sandbox-gateway";
+#[cfg(not(windows))]
 pub const DEFAULT_GATEWAY_SOCKET: &str = "127.0.0.1:7878";
 pub const DEFAULT_GATEWAY_PID: &str = "/tmp/eos-gateway.pid";
 pub const DEFAULT_MAX_CONCURRENT_CONNECTIONS: usize = 256;
 pub const SANDBOX_GATEWAY_SOCKET_ENV: &str = "SANDBOX_GATEWAY_SOCKET";
 pub const SANDBOX_GATEWAY_AUTH_TOKEN_ENV: &str = "SANDBOX_GATEWAY_AUTH_TOKEN";
+
+/// A validated gateway transport endpoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GatewayEndpoint {
+    Tcp(SocketAddr),
+    WindowsNamedPipe(String),
+    UnixSocket(PathBuf),
+}
+
+impl FromStr for GatewayEndpoint {
+    type Err = GatewayEndpointParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.trim() != value {
+            return Err(GatewayEndpointParseError::new(
+                "surrounding whitespace is not allowed",
+            ));
+        }
+        if let Some(address) = value.strip_prefix("tcp://") {
+            return parse_tcp(address);
+        }
+        if let Some(name) = value.strip_prefix("npipe://./pipe/") {
+            return parse_named_pipe(name);
+        }
+        if let Some(path) = value.strip_prefix("unix://") {
+            return parse_unix_socket(path);
+        }
+        if value.contains("://") {
+            return Err(GatewayEndpointParseError::new(
+                "supported schemes are tcp, npipe, and unix",
+            ));
+        }
+        parse_tcp(value)
+    }
+}
+
+impl std::fmt::Display for GatewayEndpoint {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Tcp(address) => write!(formatter, "tcp://{address}"),
+            Self::WindowsNamedPipe(path) => {
+                let name = path
+                    .strip_prefix(r"\\.\pipe\")
+                    .unwrap_or(path)
+                    .replace('\\', "/");
+                write!(formatter, "npipe://./pipe/{name}")
+            }
+            Self::UnixSocket(path) => write!(formatter, "unix://{}", path.display()),
+        }
+    }
+}
+
+/// An invalid gateway endpoint string.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("invalid gateway endpoint: {reason}")]
+pub struct GatewayEndpointParseError {
+    reason: String,
+}
+
+impl GatewayEndpointParseError {
+    fn new(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+        }
+    }
+}
 
 /// Gateway server config. The YAML `gateway` section feeds `bind_addr`,
 /// `pid_path`, and `max_concurrent_connections`; the auth token is runtime
@@ -60,7 +130,8 @@ impl GatewayConfig {
     /// # Errors
     /// Returns an error when a field violates gateway policy.
     pub fn validate(&self) -> Result<(), ConfigFieldError> {
-        require_socket_addr(&self.bind_addr, "gateway.bind_addr")?;
+        self.endpoint()
+            .map_err(|error| ConfigFieldError::new("gateway.bind_addr", error.to_string()))?;
         require_non_empty(&self.pid_path.to_string_lossy(), "gateway.pid_path")?;
         require_usize_at_least(
             self.max_concurrent_connections,
@@ -68,4 +139,79 @@ impl GatewayConfig {
             "gateway.max_concurrent_connections",
         )
     }
+
+    /// Parse the configured bind value into its transport-specific endpoint.
+    ///
+    /// # Errors
+    /// Returns an error when the endpoint syntax or transport value is unsafe.
+    pub fn endpoint(&self) -> Result<GatewayEndpoint, GatewayEndpointParseError> {
+        self.bind_addr.parse()
+    }
+}
+
+fn parse_tcp(value: &str) -> Result<GatewayEndpoint, GatewayEndpointParseError> {
+    let address = value.parse::<SocketAddr>().map_err(|_| {
+        GatewayEndpointParseError::new(format!("`{value}` must be an IP host:port address"))
+    })?;
+    if address.port() == 0 {
+        return Err(GatewayEndpointParseError::new(
+            "TCP port must be greater than zero",
+        ));
+    }
+    Ok(GatewayEndpoint::Tcp(address))
+}
+
+fn parse_named_pipe(value: &str) -> Result<GatewayEndpoint, GatewayEndpointParseError> {
+    validate_endpoint_segments(value, "named-pipe name")?;
+    if value.chars().any(|character| {
+        !character.is_ascii_alphanumeric() && !matches!(character, '/' | '-' | '_' | '.')
+    }) {
+        return Err(GatewayEndpointParseError::new(
+            "named-pipe name may contain only ASCII letters, digits, `/`, `-`, `_`, and `.`",
+        ));
+    }
+    let path = format!(r"\\.\pipe\{}", value.replace('/', r"\"));
+    if path.encode_utf16().count() > 256 {
+        return Err(GatewayEndpointParseError::new(
+            "named-pipe path exceeds the Windows 256-character limit",
+        ));
+    }
+    Ok(GatewayEndpoint::WindowsNamedPipe(path))
+}
+
+fn parse_unix_socket(value: &str) -> Result<GatewayEndpoint, GatewayEndpointParseError> {
+    if !value.starts_with('/') {
+        return Err(GatewayEndpointParseError::new(
+            "Unix-socket path must be absolute",
+        ));
+    }
+    let relative = value.trim_start_matches('/');
+    validate_endpoint_segments(relative, "Unix-socket path")?;
+    if value.len() > 100 {
+        return Err(GatewayEndpointParseError::new(
+            "Unix-socket path exceeds the portable 100-byte limit",
+        ));
+    }
+    if value.chars().any(char::is_control) || value.contains('\\') {
+        return Err(GatewayEndpointParseError::new(
+            "Unix-socket path contains an unsafe character",
+        ));
+    }
+    Ok(GatewayEndpoint::UnixSocket(PathBuf::from(value)))
+}
+
+fn validate_endpoint_segments(
+    value: &str,
+    description: &str,
+) -> Result<(), GatewayEndpointParseError> {
+    if value.is_empty()
+        || value
+            .split('/')
+            .any(|segment| segment.is_empty() || matches!(segment, "." | ".."))
+    {
+        return Err(GatewayEndpointParseError::new(format!(
+            "{description} must contain non-empty path segments without `.` or `..`"
+        )));
+    }
+    Ok(())
 }

--- a/crates/sandbox-config/src/configs/gateway.rs
+++ b/crates/sandbox-config/src/configs/gateway.rs
@@ -185,7 +185,9 @@ fn parse_unix_socket(value: &str) -> Result<GatewayEndpoint, GatewayEndpointPars
             "Unix-socket path must be absolute",
         ));
     }
-    let relative = value.trim_start_matches('/');
+    let relative = value
+        .strip_prefix('/')
+        .ok_or_else(|| GatewayEndpointParseError::new("Unix-socket path must be absolute"))?;
     validate_endpoint_segments(relative, "Unix-socket path")?;
     if value.len() > 100 {
         return Err(GatewayEndpointParseError::new(

--- a/crates/sandbox-config/src/configs/observability.rs
+++ b/crates/sandbox-config/src/configs/observability.rs
@@ -18,7 +18,7 @@ const MAX_MAX_DISK_BYTES: u64 = 16 * 1024 * 1024;
 const MAX_MAX_LINE_BYTES: usize = 16 * 1024;
 const MIN_RESOURCE_DISK_BYTES: u64 = 128 * 1024;
 const MAX_RESOURCE_DISK_BYTES: u64 = 4 * 1024 * 1024;
-const MIN_RESOURCE_SAMPLE_INTERVAL_MS: u64 = 250;
+const MIN_RESOURCE_SAMPLE_INTERVAL_MS: u64 = 100;
 const MAX_RESOURCE_SAMPLE_INTERVAL_MS: u64 = 600_000;
 const MIN_DIAGNOSTIC_ARTIFACT_BYTES: usize = 4 * 1024;
 pub const MAX_DIAGNOSTIC_ARTIFACT_BYTES: usize = 1024 * 1024;
@@ -141,7 +141,7 @@ impl ObservabilityConfig {
         {
             return Err(ConfigFieldError::new(
                 "observability.resource_stats.sample_interval_ms",
-                "must be between 250 and 600000",
+                "must be between 100 and 600000",
             ));
         }
         if !(MIN_RESOURCE_DISK_BYTES..=MAX_RESOURCE_DISK_BYTES)

--- a/crates/sandbox-config/tests/unit/configs/gateway.rs
+++ b/crates/sandbox-config/tests/unit/configs/gateway.rs
@@ -70,6 +70,7 @@ fn gateway_endpoints_reject_unsafe_or_ambiguous_values() {
         "npipe://./pipe/../escape",
         "npipe://./pipe/name\\escape",
         "unix://relative.sock",
+        "unix:////tmp/ambiguous.sock",
         "unix:///tmp/../escape.sock",
         "unix:///tmp//ambiguous.sock",
     ];

--- a/crates/sandbox-config/tests/unit/configs/gateway.rs
+++ b/crates/sandbox-config/tests/unit/configs/gateway.rs
@@ -19,12 +19,76 @@ fn gateway_server_config_constructs_from_defaults() {
 }
 
 #[test]
+fn gateway_endpoints_parse_supported_transports_and_legacy_tcp() {
+    let endpoints = [
+        (
+            "127.0.0.1:7878",
+            GatewayEndpoint::Tcp("127.0.0.1:7878".parse().expect("socket address")),
+        ),
+        (
+            "tcp://[::1]:7878",
+            GatewayEndpoint::Tcp("[::1]:7878".parse().expect("socket address")),
+        ),
+        (
+            "npipe://./pipe/ephemeral-sandbox/user-1",
+            GatewayEndpoint::WindowsNamedPipe(
+                r"\\.\pipe\ephemeral-sandbox\user-1".to_owned(),
+            ),
+        ),
+        (
+            "unix:///tmp/ephemeral-sandbox.sock",
+            GatewayEndpoint::UnixSocket(PathBuf::from("/tmp/ephemeral-sandbox.sock")),
+        ),
+    ];
+
+    for (raw, expected) in endpoints {
+        let parsed = raw
+            .parse::<GatewayEndpoint>()
+            .expect("supported endpoint parses");
+        assert_eq!(parsed, expected);
+        assert_eq!(
+            parsed.to_string(),
+            match raw {
+                "127.0.0.1:7878" => "tcp://127.0.0.1:7878",
+                _ => raw,
+            }
+        );
+    }
+}
+
+#[test]
+fn gateway_endpoints_reject_unsafe_or_ambiguous_values() {
+    let invalid = [
+        "",
+        " 127.0.0.1:7878",
+        "127.0.0.1:7878 ",
+        "http://127.0.0.1:7878",
+        "tcp://localhost:7878",
+        "tcp://127.0.0.1:0",
+        "npipe://server/pipe/name",
+        "npipe://./pipe/",
+        "npipe://./pipe/../escape",
+        "npipe://./pipe/name\\escape",
+        "unix://relative.sock",
+        "unix:///tmp/../escape.sock",
+        "unix:///tmp//ambiguous.sock",
+    ];
+
+    for value in invalid {
+        let error = value
+            .parse::<GatewayEndpoint>()
+            .expect_err("unsafe endpoint must fail");
+        assert!(error.to_string().contains("invalid gateway endpoint"));
+    }
+}
+
+#[test]
 fn config_gateway_defaults_preserve_shipped_policy() {
     // prd.yml carries no gateway section, so the section must load to
     // today's exact constants.
     let config = GatewayConfig::default();
     config.validate().expect("default gateway config is valid");
-    assert_eq!(config.bind_addr, "127.0.0.1:7878");
+    assert_eq!(config.bind_addr, DEFAULT_GATEWAY_SOCKET);
     assert_eq!(config.pid_path, PathBuf::from("/tmp/eos-gateway.pid"));
     assert_eq!(config.max_concurrent_connections, 256);
     assert!(config.auth_token.is_none());
@@ -84,6 +148,20 @@ fn config_validation_rejects_gateway_edge_values() {
         (
             GatewayConfig {
                 bind_addr: "not-an-address".to_owned(),
+                ..GatewayConfig::default()
+            },
+            "gateway.bind_addr",
+        ),
+        (
+            GatewayConfig {
+                bind_addr: "npipe://./pipe/../escape".to_owned(),
+                ..GatewayConfig::default()
+            },
+            "gateway.bind_addr",
+        ),
+        (
+            GatewayConfig {
+                bind_addr: "unix://relative.sock".to_owned(),
                 ..GatewayConfig::default()
             },
             "gateway.bind_addr",

--- a/crates/sandbox-config/tests/unit/configs/observability.rs
+++ b/crates/sandbox-config/tests/unit/configs/observability.rs
@@ -131,7 +131,7 @@ fn config_validation_rejects_observability_edge_values() {
     assert_invalid(cfg, "observability.max_line_bytes");
 
     let mut cfg = prd_config();
-    cfg.resource_stats.sample_interval_ms = 249;
+    cfg.resource_stats.sample_interval_ms = 99;
     assert_invalid(cfg, "observability.resource_stats.sample_interval_ms");
 
     let mut cfg = prd_config();

--- a/crates/sandbox-config/tests/unit/lib.rs
+++ b/crates/sandbox-config/tests/unit/lib.rs
@@ -19,6 +19,25 @@ fn load_path_reads_committed_baseline() {
 }
 
 #[test]
+fn windows_release_resource_ring_matches_paper_sampling_cadence() {
+    let baseline = ConfigPath::prd().expect("resolve config directory");
+    let windows = baseline
+        .as_path()
+        .parent()
+        .expect("config directory")
+        .join("windows-amd64.yml");
+    let doc = load_path(&windows).expect("Windows release config loads");
+    let observability = doc
+        .section::<configs::observability::ObservabilityConfig>("observability")
+        .expect("observability section exists");
+
+    observability
+        .validate()
+        .expect("Windows observability config is valid");
+    assert_eq!(observability.resource_stats.sample_interval_ms, 100);
+}
+
+#[test]
 fn merge_recurses_objects_replaces_scalars_and_replaces_arrays() {
     let mut baseline = parse_doc(
         r#"

--- a/crates/sandbox-daemon/Cargo.toml
+++ b/crates/sandbox-daemon/Cargo.toml
@@ -42,6 +42,7 @@ tikv-jemalloc-ctl = { workspace = true, optional = true }
 [dev-dependencies]
 sandbox-runtime-layerstack.workspace = true
 sandbox-runtime-workspace.workspace = true
+rustix = { workspace = true, features = ["pipe"] }
 
 [lints]
 workspace = true

--- a/crates/sandbox-daemon/src/observability/mod.rs
+++ b/crates/sandbox-daemon/src/observability/mod.rs
@@ -1,7 +1,7 @@
 pub(crate) mod adapter;
 pub(crate) mod allocator;
 pub(crate) mod diagnostics;
-mod resources;
+pub(crate) mod resources;
 mod service;
 
 pub use service::DaemonObservability;

--- a/crates/sandbox-daemon/src/observability/resources.rs
+++ b/crates/sandbox-daemon/src/observability/resources.rs
@@ -1,27 +1,58 @@
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{mpsc, Arc};
+use std::sync::{mpsc, Arc, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use sandbox_config::configs::observability::ResourceStatsConfig;
 use sandbox_observability_telemetry::collect::cgroup::CgroupSample;
+use sandbox_observability_telemetry::collect::disk::sample_upperdir;
 use sandbox_observability_telemetry::{
-    Attrs, Record, Sample, Sink, SinkStats, COUNTERS_METRIC_KEY, MAX_LINE_BYTES,
+    Attrs, Record, Sample, Sink, SinkStats, WalkBudget, COUNTERS_METRIC_KEY, MAX_LINE_BYTES,
 };
+use sandbox_runtime::SandboxRuntimeOperations;
 use serde_json::{json, Value};
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 
-pub(super) struct ResourceSampler {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkspaceDiskTarget {
+    pub(crate) workspace_id: String,
+    pub(crate) upperdir: Option<PathBuf>,
+}
+
+pub(crate) trait WorkspaceDiskSource: Send + Sync {
+    fn workspace_disk_targets(&self) -> Vec<WorkspaceDiskTarget>;
+}
+
+impl WorkspaceDiskSource for SandboxRuntimeOperations {
+    fn workspace_disk_targets(&self) -> Vec<WorkspaceDiskTarget> {
+        self.observability_snapshot()
+            .workspaces
+            .into_iter()
+            .map(|workspace| WorkspaceDiskTarget {
+                workspace_id: workspace.workspace_id.0,
+                upperdir: workspace.upperdir,
+            })
+            .collect()
+    }
+}
+
+pub(crate) struct ResourceSampler {
     enabled: bool,
     sample_interval: Duration,
     cgroup_dir: Result<PathBuf, String>,
+    sampling: WalkBudget,
+    workspace_source: OnceLock<Arc<dyn WorkspaceDiskSource>>,
     sink: Arc<Sink>,
     collection_failures: AtomicU64,
 }
 
 impl ResourceSampler {
-    pub(super) fn new(config: ResourceStatsConfig, resource_path: PathBuf) -> Self {
+    pub(crate) fn new(
+        config: ResourceStatsConfig,
+        resource_path: PathBuf,
+        sampling: WalkBudget,
+    ) -> Self {
         let cgroup_dir = std::fs::read_to_string("/proc/self/cgroup")
             .map_err(|error| format!("/proc/self/cgroup: {error}"))
             .and_then(|contents| resolve_cgroup_dir(&contents, Path::new("/sys/fs/cgroup")));
@@ -29,6 +60,8 @@ impl ResourceSampler {
             enabled: config.enabled,
             sample_interval: Duration::from_millis(config.sample_interval_ms),
             cgroup_dir,
+            sampling,
+            workspace_source: OnceLock::new(),
             sink: Arc::new(Sink::with_budget(
                 resource_path,
                 MAX_LINE_BYTES,
@@ -38,7 +71,12 @@ impl ResourceSampler {
         }
     }
 
-    pub(super) fn start(self: &Arc<Self>, tasks: &TaskTracker, shutdown: CancellationToken) {
+    pub(crate) fn bind_workspace_source(&self, source: Arc<dyn WorkspaceDiskSource>) {
+        let inserted = self.workspace_source.set(source).is_ok();
+        debug_assert!(inserted, "workspace disk source bound more than once");
+    }
+
+    pub(crate) fn start(self: &Arc<Self>, tasks: &TaskTracker, shutdown: CancellationToken) {
         if !self.enabled {
             return;
         }
@@ -57,7 +95,13 @@ impl ResourceSampler {
         });
     }
 
-    pub(super) fn sample_once(&self) {
+    pub(crate) fn sample_once(&self) {
+        let timestamp = unix_now_ms();
+        self.sample_cgroup(timestamp);
+        self.sample_workspaces(timestamp);
+    }
+
+    fn sample_cgroup(&self, timestamp: i64) {
         let cgroup = match &self.cgroup_dir {
             Ok(path) => CgroupSample::read(path),
             Err(_) => {
@@ -93,20 +137,61 @@ impl ResourceSampler {
             .collect::<Vec<_>>();
         metrics.insert(COUNTERS_METRIC_KEY.to_owned(), json!(counters));
         let record = Record::Sample(Sample {
-            ts: unix_now_ms(),
+            ts: timestamp,
             scope: "sandbox".to_owned(),
             metrics,
         });
         let _ = self.sink.append_strict(&record);
     }
 
-    pub(super) fn sink_stats(&self) -> SinkStats {
+    fn sample_workspaces(&self, timestamp: i64) {
+        let Some(source) = self.workspace_source.get() else {
+            return;
+        };
+        for target in source.workspace_disk_targets() {
+            let (metrics, failed) = workspace_metrics(target.upperdir.as_deref(), self.sampling);
+            if failed {
+                self.collection_failures.fetch_add(1, Ordering::Relaxed);
+            }
+            let record = Record::Sample(Sample {
+                ts: timestamp,
+                scope: target.workspace_id,
+                metrics,
+            });
+            let _ = self.sink.append_strict(&record);
+        }
+    }
+
+    pub(crate) fn sink_stats(&self) -> SinkStats {
         self.sink.stats()
     }
 
-    pub(super) fn collection_failures(&self) -> u64 {
+    pub(crate) fn collection_failures(&self) -> u64 {
         self.collection_failures.load(Ordering::Relaxed)
     }
+}
+
+fn workspace_metrics(upperdir: Option<&Path>, budget: WalkBudget) -> (Attrs, bool) {
+    let Some(upperdir) = upperdir else {
+        let mut metrics = Attrs::new();
+        metrics.insert("disk_truncated".to_owned(), Value::Bool(true));
+        return (metrics, true);
+    };
+    let sample = sample_upperdir(upperdir, budget);
+    let read_failed = sample.read_error_count != Some(0);
+    let incomplete = sample.truncated != Some(false) || read_failed;
+    let mut metrics = Attrs::new();
+    insert_option(&mut metrics, "disk_bytes", sample.upperdir_bytes);
+    if !incomplete {
+        insert_option(
+            &mut metrics,
+            "disk_allocated_bytes",
+            sample.upperdir_allocated_bytes,
+        );
+    }
+    insert_option(&mut metrics, "files", sample.file_count);
+    metrics.insert("disk_truncated".to_owned(), Value::Bool(incomplete));
+    (metrics, read_failed)
 }
 
 fn insert_option<T: serde::Serialize>(metrics: &mut Attrs, key: &str, value: Option<T>) {
@@ -174,6 +259,8 @@ mod tests {
             enabled: true,
             sample_interval: interval,
             cgroup_dir: Ok(cgroup_dir),
+            sampling: WalkBudget::default(),
+            workspace_source: OnceLock::new(),
             sink: Arc::new(Sink::with_budget(resource_path, MAX_LINE_BYTES, 128 * 1024)),
             collection_failures: AtomicU64::new(0),
         }

--- a/crates/sandbox-daemon/src/observability/service.rs
+++ b/crates/sandbox-daemon/src/observability/service.rs
@@ -12,7 +12,7 @@ use sandbox_observability_telemetry::collect::process_topology::{
 use sandbox_observability_telemetry::{
     record, ObservabilityPaths, Observer, ObserverConfig, Reader, Sink, WalkBudget,
 };
-use sandbox_runtime::SandboxRuntimeConfig;
+use sandbox_runtime::{SandboxRuntimeConfig, SandboxRuntimeOperations};
 
 use crate::rpc::ServerConfig;
 
@@ -54,9 +54,14 @@ impl DaemonObservability {
                 config.observability.max_disk_bytes,
             ),
         );
+        let sampling = WalkBudget {
+            max_nodes: config.observability.sampling.max_walk_nodes,
+            max_depth: config.observability.sampling.max_walk_depth,
+        };
         let resource_sampler = Arc::new(ResourceSampler::new(
             config.observability.resource_stats,
             paths.resource_log_path().to_path_buf(),
+            sampling,
         ));
         let diagnostics = DiagnosticTracker::new(
             config.observability.diagnostics,
@@ -78,10 +83,7 @@ impl DaemonObservability {
                 infrastructure_thread_allowance: Some(INFRASTRUCTURE_THREAD_ALLOWANCE),
             },
             diagnostics,
-            sampling: WalkBudget {
-                max_nodes: config.observability.sampling.max_walk_nodes,
-                max_depth: config.observability.sampling.max_walk_depth,
-            },
+            sampling,
             views: config.observability.views,
         })
     }
@@ -118,6 +120,10 @@ impl DaemonObservability {
         shutdown: tokio_util::sync::CancellationToken,
     ) {
         self.resource_sampler.start(tasks, shutdown);
+    }
+
+    pub(crate) fn bind_runtime_operations(&self, operations: Arc<SandboxRuntimeOperations>) {
+        self.resource_sampler.bind_workspace_source(operations);
     }
 
     pub(super) fn resource_sink_stats(&self) -> sandbox_observability_telemetry::SinkStats {

--- a/crates/sandbox-daemon/src/rpc/runtime.rs
+++ b/crates/sandbox-daemon/src/rpc/runtime.rs
@@ -171,6 +171,9 @@ impl SandboxDaemonServer {
             runtime_config,
             resolve_observer(observability.as_ref()),
         ));
+        if let Some(observability) = &observability {
+            observability.bind_runtime_operations(Arc::clone(&operations));
+        }
         Self {
             blocking_admission: BlockingAdmission::new(config.max_blocking_requests),
             connection_admission: ConnectionAdmission::new(config.max_concurrent_connections),

--- a/crates/sandbox-daemon/tests/unit/http.rs
+++ b/crates/sandbox-daemon/tests/unit/http.rs
@@ -593,7 +593,7 @@ async fn daemon_shutdown_runs_runtime_teardown_and_removes_published_artifacts()
     Ok(())
 }
 
-fn test_operations(root: &Path) -> TestResult<Arc<SandboxRuntimeOperations>> {
+pub(crate) fn test_operations(root: &Path) -> TestResult<Arc<SandboxRuntimeOperations>> {
     let workspace_root = root.join("workspace");
     let layer_stack_root = root.join("layer-stack");
     std::fs::create_dir_all(&workspace_root)?;
@@ -644,11 +644,25 @@ fn test_operations(root: &Path) -> TestResult<Arc<SandboxRuntimeOperations>> {
                 ))
             }),
             create_workspace: Box::new(move |request: CreateWorkspaceRequest| {
-                Ok(WorkspaceHandle::without_launch_for_test(
+                let upperdir = create_workspace_root
+                    .join("upper")
+                    .join(&request.workspace_session_id.0);
+                let workdir = create_workspace_root
+                    .join("work")
+                    .join(&request.workspace_session_id.0);
+                std::fs::create_dir_all(&upperdir).map_err(|error| WorkspaceError::Setup {
+                    step: format!("create test upperdir: {error}"),
+                })?;
+                std::fs::create_dir_all(&workdir).map_err(|error| WorkspaceError::Setup {
+                    step: format!("create test workdir: {error}"),
+                })?;
+                Ok(WorkspaceHandle::holder_backed_for_test(
                     request.workspace_session_id,
                     create_workspace_root.clone(),
                     request.network,
                     create_snapshot.clone(),
+                    upperdir,
+                    workdir,
                 ))
             }),
             capture_changes: Box::new(

--- a/crates/sandbox-daemon/tests/unit/observability.rs
+++ b/crates/sandbox-daemon/tests/unit/observability.rs
@@ -7,20 +7,27 @@ use std::io::Read as _;
 use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{mpsc, Arc};
+use std::sync::{mpsc, Arc, RwLock};
 use std::thread;
 use std::time::Duration;
 
+use crate::observability::resources::{
+    ResourceSampler, WorkspaceDiskSource, WorkspaceDiskTarget,
+};
 use crate::observability::diagnostics::DiagnosticTracker;
 use crate::observability::DaemonObservability;
-use crate::rpc::{SandboxDaemonServer, ServerConfig};
-use sandbox_config::configs::observability::{DiagnosticsConfig, ObservabilityConfig};
+use crate::rpc::{
+    BlockingAdmission, ConnectionAdmission, SandboxDaemonServer, ServerConfig,
+};
+use sandbox_config::configs::observability::{
+    DiagnosticsConfig, ObservabilityConfig, ResourceStatsConfig,
+};
 use sandbox_observability_query::ports::DaemonMetricsRequestClass;
 use sandbox_observability_telemetry::collect::process_topology::{
     DaemonDiagnosticTrigger, DaemonDiagnosticWorkspaceHolder, DaemonOwnershipMetrics,
     DaemonProcessMetrics, DaemonRuntimeConfigMetrics, DaemonRuntimeUsage,
 };
-use sandbox_observability_telemetry::ObservabilityPaths;
+use sandbox_observability_telemetry::{ObservabilityPaths, Record, Sample, WalkBudget};
 use sandbox_operation_catalog::observability::{
     CGROUP_SPEC, DAEMON_SPEC, EVENTS_SPEC, LAYERSTACK_SPEC, SNAPSHOT_SPEC, TOPOLOGY_SPEC,
     TRACE_SPEC,
@@ -35,6 +42,8 @@ use sandbox_runtime::{
 };
 use serde_json::{json, Value};
 use sha2::{Digest as _, Sha256};
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
 
 type TestResult<T = ()> = Result<T, Box<dyn Error + Send + Sync>>;
 const TOPOLOGY_REQUEST: DaemonMetricsRequestClass = DaemonMetricsRequestClass::Topology;
@@ -116,6 +125,209 @@ fn from_config_disabled_when_sandbox_id_is_missing() {
     let config = server_config(&root, None);
     let runtime = runtime_config(&root).expect("runtime config");
     assert!(DaemonObservability::from_config(&config, &runtime).is_none());
+}
+
+#[test]
+fn workspace_resource_samples_emit_exact_metrics_and_refresh() -> TestResult {
+    let root = test_root("workspace-resource-emission");
+    let upperdir = root.join("upper");
+    fs::create_dir_all(&upperdir)?;
+    fs::write(upperdir.join("alpha"), b"abc")?;
+    fs::write(upperdir.join("beta"), b"defg")?;
+    let (sampler, source, resource_path) =
+        workspace_resource_sampler(&root, WalkBudget::default(), Duration::from_millis(10));
+    source.replace(vec![workspace_disk_target("workspace-1", &upperdir)]);
+
+    sampler.sample_once();
+    let first = latest_workspace_sample(&resource_path, "workspace-1")?;
+    assert_eq!(first.metrics["disk_bytes"], 7);
+    assert_eq!(first.metrics["files"], 2);
+    assert_eq!(first.metrics["disk_truncated"], false);
+    assert!(first.metrics["disk_allocated_bytes"].as_u64().is_some());
+    let mut metric_keys = first.metrics.keys().map(String::as_str).collect::<Vec<_>>();
+    metric_keys.sort_unstable();
+    assert_eq!(
+        metric_keys,
+        [
+            "disk_allocated_bytes",
+            "disk_bytes",
+            "disk_truncated",
+            "files",
+        ]
+    );
+
+    fs::write(upperdir.join("gamma"), b"hijkl")?;
+    let refreshed = loop {
+        thread::sleep(Duration::from_millis(2));
+        sampler.sample_once();
+        let latest = latest_workspace_sample(&resource_path, "workspace-1")?;
+        if latest.ts > first.ts {
+            break latest;
+        }
+    };
+    assert_eq!(refreshed.metrics["disk_bytes"], 12);
+    assert_eq!(refreshed.metrics["files"], 3);
+    Ok(())
+}
+
+#[test]
+fn workspace_resource_samples_fail_closed_on_truncation_and_read_error() -> TestResult {
+    let root = test_root("workspace-resource-incomplete");
+    let upperdir = root.join("upper");
+    fs::create_dir_all(&upperdir)?;
+    fs::write(upperdir.join("alpha"), b"abc")?;
+    let (sampler, source, resource_path) = workspace_resource_sampler(
+        &root,
+        WalkBudget {
+            max_nodes: 1,
+            max_depth: 64,
+        },
+        Duration::from_millis(10),
+    );
+    source.replace(vec![workspace_disk_target("workspace-truncated", &upperdir)]);
+
+    sampler.sample_once();
+    let truncated = latest_workspace_sample(&resource_path, "workspace-truncated")?;
+    assert_eq!(truncated.metrics["disk_truncated"], true);
+    assert!(truncated.metrics.get("disk_allocated_bytes").is_none());
+
+    source.replace(vec![workspace_disk_target(
+        "workspace-error",
+        &root.join("missing-upper"),
+    )]);
+    sampler.sample_once();
+    let failed = latest_workspace_sample(&resource_path, "workspace-error")?;
+    assert_eq!(failed.metrics["disk_bytes"], 0);
+    assert_eq!(failed.metrics["files"], 0);
+    assert_eq!(failed.metrics["disk_truncated"], true);
+    assert!(failed.metrics.get("disk_allocated_bytes").is_none());
+    Ok(())
+}
+
+#[test]
+fn workspace_resource_sampler_stops_emitting_after_workspace_disappears() -> TestResult {
+    let root = test_root("workspace-resource-disappearance");
+    let upperdir = root.join("upper");
+    fs::create_dir_all(&upperdir)?;
+    let (sampler, source, resource_path) =
+        workspace_resource_sampler(&root, WalkBudget::default(), Duration::from_millis(10));
+    source.replace(vec![workspace_disk_target("workspace-1", &upperdir)]);
+    sampler.sample_once();
+    assert_eq!(workspace_samples(&resource_path, "workspace-1")?.len(), 1);
+
+    source.replace(Vec::new());
+    sampler.sample_once();
+    assert_eq!(
+        workspace_samples(&resource_path, "workspace-1")?.len(),
+        1,
+        "a disappeared workspace must not receive another resource sample"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn workspace_resource_sampler_shutdown_joins_before_returning() -> TestResult {
+    let root = test_root("workspace-resource-shutdown");
+    let upperdir = root.join("upper");
+    fs::create_dir_all(&upperdir)?;
+    fs::write(upperdir.join("alpha"), b"abc")?;
+    let (sampler, source, resource_path) =
+        workspace_resource_sampler(&root, WalkBudget::default(), Duration::from_millis(2));
+    source.replace(vec![workspace_disk_target("workspace-1", &upperdir)]);
+    let tasks = TaskTracker::new();
+    let shutdown = CancellationToken::new();
+    sampler.start(&tasks, shutdown.clone());
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if workspace_samples(&resource_path, "workspace-1")
+                .map(|samples| samples.len() >= 2)
+                .unwrap_or(false)
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("workspace sampler emits before timeout");
+
+    shutdown.cancel();
+    tasks.close();
+    tasks.wait().await;
+    let bytes_after_join = fs::read(&resource_path)?;
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    assert_eq!(fs::read(&resource_path)?, bytes_after_join);
+    Ok(())
+}
+
+#[tokio::test]
+async fn daemon_snapshot_reads_live_workspace_sample_from_resource_store() -> TestResult {
+    let root = test_root("workspace-resource-snapshot");
+    let operations = crate::http_tests::test_operations(&root)?;
+    let upperdir = operations
+        .observability_snapshot()
+        .workspaces
+        .into_iter()
+        .find(|workspace| workspace.workspace_id.0 == "live-1")
+        .and_then(|workspace| workspace.upperdir)
+        .expect("live workspace exposes upperdir");
+    fs::write(upperdir.join("sample-payload"), vec![b'x'; 4096])?;
+    let mut config = server_config(&root, Some("sandbox-1"));
+    config.observability.resource_stats.sample_interval_ms = 2;
+    let observability = Arc::new(
+        DaemonObservability::from_config(&config, &runtime_config(&root.join("runtime-config"))?)
+            .expect("configured observability"),
+    );
+    observability.bind_runtime_operations(Arc::clone(&operations));
+    let server = SandboxDaemonServer {
+        blocking_admission: BlockingAdmission::new(config.max_blocking_requests),
+        connection_admission: ConnectionAdmission::new(config.max_concurrent_connections),
+        async_tasks: TaskTracker::new(),
+        config,
+        operations,
+        observability: Some(observability),
+        shutdown: CancellationToken::new(),
+    };
+
+    let resource_tasks = TaskTracker::new();
+    let resource_shutdown = CancellationToken::new();
+    server
+        .observability
+        .as_ref()
+        .expect("configured observability")
+        .start_resource_sampler(&resource_tasks, resource_shutdown.clone());
+    let snapshot = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let response = server
+                .dispatch_bytes(
+                    request_bytes(SNAPSHOT_SPEC.name, "snapshot-workspace", json!({}))
+                        .expect("snapshot request"),
+                    false,
+                )
+                .await;
+            let value = response.as_json_value();
+            if value
+                .pointer("/workspaces/0/resources/latest/metrics/disk_allocated_bytes")
+                .is_some_and(Value::is_u64)
+            {
+                break value.clone();
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("snapshot receives a complete workspace resource sample");
+    assert_eq!(snapshot["workspaces"][0]["workspace_id"], "live-1");
+    assert_eq!(
+        snapshot["workspaces"][0]["resources"]["latest"]["metrics"]["disk_truncated"],
+        false
+    );
+
+    resource_shutdown.cancel();
+    resource_tasks.close();
+    resource_tasks.wait().await;
+    Ok(())
 }
 
 #[test]
@@ -1420,6 +1632,81 @@ fn daemon_server_from(root: &Path, config: ServerConfig) -> TestResult<SandboxDa
         config,
         runtime_config(root)?,
     ))
+}
+
+#[derive(Default)]
+struct FakeWorkspaceDiskSource {
+    targets: RwLock<Vec<WorkspaceDiskTarget>>,
+}
+
+impl FakeWorkspaceDiskSource {
+    fn replace(&self, targets: Vec<WorkspaceDiskTarget>) {
+        *self.targets.write().expect("lock workspace disk targets") = targets;
+    }
+}
+
+impl WorkspaceDiskSource for FakeWorkspaceDiskSource {
+    fn workspace_disk_targets(&self) -> Vec<WorkspaceDiskTarget> {
+        self.targets
+            .read()
+            .expect("lock workspace disk targets")
+            .clone()
+    }
+}
+
+fn workspace_resource_sampler(
+    root: &Path,
+    sampling: WalkBudget,
+    interval: Duration,
+) -> (
+    Arc<ResourceSampler>,
+    Arc<FakeWorkspaceDiskSource>,
+    PathBuf,
+) {
+    let resource_path = root.join("resources.ndjson");
+    let sampler = Arc::new(ResourceSampler::new(
+        ResourceStatsConfig {
+            enabled: true,
+            sample_interval_ms: u64::try_from(interval.as_millis())
+                .expect("test interval fits u64"),
+            max_disk_bytes: 128 * 1024,
+        },
+        resource_path.clone(),
+        sampling,
+    ));
+    let source = Arc::new(FakeWorkspaceDiskSource::default());
+    sampler.bind_workspace_source(source.clone());
+    (sampler, source, resource_path)
+}
+
+fn workspace_disk_target(workspace_id: &str, upperdir: &Path) -> WorkspaceDiskTarget {
+    WorkspaceDiskTarget {
+        workspace_id: workspace_id.to_owned(),
+        upperdir: Some(upperdir.to_path_buf()),
+    }
+}
+
+fn workspace_samples(resource_path: &Path, scope: &str) -> TestResult<Vec<Sample>> {
+    let contents = match fs::read_to_string(resource_path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error.into()),
+    };
+    let mut samples = Vec::new();
+    for line in contents.lines() {
+        if let Record::Sample(sample) = serde_json::from_str::<Record>(line)? {
+            if sample.scope == scope {
+                samples.push(sample);
+            }
+        }
+    }
+    Ok(samples)
+}
+
+fn latest_workspace_sample(resource_path: &Path, scope: &str) -> TestResult<Sample> {
+    workspace_samples(resource_path, scope)?
+        .pop()
+        .ok_or_else(|| format!("missing resource sample for workspace {scope}").into())
 }
 
 fn request_bytes(op: &str, request_id: &str, args: Value) -> TestResult<Vec<u8>> {

--- a/crates/sandbox-daemon/tests/unit/runner.rs
+++ b/crates/sandbox-daemon/tests/unit/runner.rs
@@ -1,8 +1,9 @@
+use std::fs::File;
 use std::io::{Read, Write};
 use std::os::fd::AsRawFd;
-use std::os::unix::net::UnixStream;
 
 use anyhow::{bail, Context, Result};
+use rustix::pipe::pipe;
 
 use crate::runner_cli::{mount_overlay::mount_overlay_result, open_fd_for_write, RunnerCliConfig};
 
@@ -85,7 +86,8 @@ fn runner_cli_rejects_positional_request_fd() -> Result<()> {
 
 #[test]
 fn result_fd_writer_writes_to_fd_peer() -> Result<()> {
-    let (mut read_end, write_end) = UnixStream::pair().context("create result pair")?;
+    let (read_end, write_end) = pipe().context("create result pipe")?;
+    let mut read_end = File::from(read_end);
     let mut writer = open_fd_for_write(write_end.as_raw_fd()).context("open result fd")?;
 
     writer.write_all(b"{\"exit_code\":0}")?;

--- a/crates/sandbox-gateway/src/daemon_client.rs
+++ b/crates/sandbox-gateway/src/daemon_client.rs
@@ -1,10 +1,9 @@
-use std::thread;
-use std::time::Duration;
+use std::io::{self, Read, Write};
+use std::net::{Shutdown, TcpStream, ToSocketAddrs};
+use std::time::{Duration, Instant};
 
 use sandbox_manager::{ManagerError, SandboxDaemonClient, SandboxDaemonEndpoint};
 use sandbox_operation_contract::{OperationRequest, OperationResponse};
-use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader};
-use tokio::net::TcpStream;
 
 const MAX_RESPONSE_BYTES: usize = sandbox_protocol::ProtocolLimits::DEFAULT_MAX_REQUEST_BYTES;
 
@@ -25,22 +24,9 @@ impl SandboxDaemonClient for TcpSandboxDaemonClient {
         request: OperationRequest,
         timeout_override: Option<Duration>,
     ) -> Result<OperationResponse, ManagerError> {
-        let host = endpoint.host.clone();
-        let port = endpoint.port;
         let request_line = request_line(&request, &endpoint.auth_token)?;
         let timeout = timeout_override.unwrap_or_else(default_request_timeout);
-        if tokio::runtime::Handle::try_current().is_ok() {
-            let worker = thread::Builder::new()
-                .name("sandbox-daemon-client".to_owned())
-                .spawn(move || run_exchange(host, port, request_line, timeout))
-                .map_err(|error| ManagerError::ForwardingFailed {
-                    message: format!("failed to spawn daemon client worker: {error}"),
-                })?;
-            return worker.join().map_err(|_| ManagerError::ForwardingFailed {
-                message: "daemon client worker panicked".to_owned(),
-            })?;
-        }
-        run_exchange(host, port, request_line, timeout)
+        run_exchange(&endpoint.host, endpoint.port, &request_line, timeout)
     }
 }
 
@@ -49,67 +35,116 @@ fn default_request_timeout() -> Duration {
 }
 
 fn run_exchange(
-    host: String,
+    host: &str,
     port: u16,
-    request_line: Vec<u8>,
+    request_line: &[u8],
     timeout: Duration,
 ) -> Result<OperationResponse, ManagerError> {
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_io()
-        .enable_time()
-        .build()
-        .map_err(|error| ManagerError::ForwardingFailed {
-            message: format!("failed to build daemon client runtime: {error}"),
-        })?;
-    runtime.block_on(async move {
-        tokio::time::timeout(timeout, tcp_exchange(host, port, request_line))
-            .await
-            .map_err(|_| ManagerError::ForwardingFailed {
-                message: format!("daemon request timed out after {} ms", timeout.as_millis()),
-            })?
-    })
+    let deadline = RequestDeadline::new(timeout);
+    tcp_exchange(host, port, request_line, &deadline)
 }
 
-async fn tcp_exchange(
-    host: String,
+fn tcp_exchange(
+    host: &str,
     port: u16,
-    request_line: Vec<u8>,
+    request_line: &[u8],
+    deadline: &RequestDeadline,
 ) -> Result<OperationResponse, ManagerError> {
-    let mut stream = TcpStream::connect((host.as_str(), port))
-        .await
-        .map_err(|error| ManagerError::ForwardingFailed {
-            message: format!("connect {host}:{port} failed: {error}"),
-        })?;
+    deadline.remaining()?;
+    let addresses = (host, port)
+        .to_socket_addrs()
+        .map_err(|error| deadline.io_error(error, format!("connect {host}:{port} failed")))?;
+    deadline.remaining()?;
+    let mut last_connect_error = None;
+    let mut stream = None;
+    for address in addresses {
+        match TcpStream::connect_timeout(&address, deadline.remaining()?) {
+            Ok(connected) => {
+                stream = Some(connected);
+                break;
+            }
+            Err(error) => {
+                if deadline.is_timeout(&error) {
+                    return Err(deadline.timeout_error());
+                }
+                last_connect_error = Some(error);
+            }
+        }
+    }
+    let mut stream = stream.ok_or_else(|| {
+        let error = last_connect_error.unwrap_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::AddrNotAvailable,
+                "resolved address list was empty",
+            )
+        });
+        deadline.io_error(error, format!("connect {host}:{port} failed"))
+    })?;
+    write_request(&mut stream, request_line, deadline)?;
     stream
-        .write_all(&request_line)
-        .await
-        .map_err(|error| ManagerError::ForwardingFailed {
-            message: format!("write daemon request failed: {error}"),
-        })?;
-    stream
-        .shutdown()
-        .await
-        .map_err(|error| ManagerError::ForwardingFailed {
-            message: format!("shutdown daemon request stream failed: {error}"),
-        })?;
-    read_response_line(stream).await
+        .shutdown(Shutdown::Write)
+        .map_err(|error| deadline.io_error(error, "shutdown daemon request stream failed"))?;
+    deadline.remaining()?;
+    read_response_line(stream, deadline)
 }
 
-async fn read_response_line<S>(stream: S) -> Result<OperationResponse, ManagerError>
-where
-    S: AsyncRead + Unpin,
-{
-    let limit = u64::try_from(MAX_RESPONSE_BYTES)
-        .unwrap_or(u64::MAX)
-        .saturating_add(1);
-    let mut reader = BufReader::new(stream.take(limit));
+fn write_request(
+    stream: &mut TcpStream,
+    mut request_line: &[u8],
+    deadline: &RequestDeadline,
+) -> Result<(), ManagerError> {
+    while !request_line.is_empty() {
+        stream
+            .set_write_timeout(Some(deadline.remaining()?))
+            .map_err(|error| deadline.io_error(error, "write daemon request failed"))?;
+        match stream.write(request_line) {
+            Ok(0) => {
+                return Err(deadline.io_error(
+                    io::Error::new(io::ErrorKind::WriteZero, "failed to write whole buffer"),
+                    "write daemon request failed",
+                ));
+            }
+            Ok(written) => request_line = &request_line[written..],
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) => {
+                return Err(deadline.io_error(error, "write daemon request failed"));
+            }
+        }
+    }
+    deadline.remaining()?;
+    Ok(())
+}
+
+fn read_response_line(
+    mut stream: TcpStream,
+    deadline: &RequestDeadline,
+) -> Result<OperationResponse, ManagerError> {
     let mut line = Vec::new();
-    reader
-        .read_until(b'\n', &mut line)
-        .await
-        .map_err(|error| ManagerError::ForwardingFailed {
-            message: format!("read daemon response failed: {error}"),
-        })?;
+    let mut buffer = [0_u8; 8 * 1024];
+    loop {
+        let remaining_capacity = MAX_RESPONSE_BYTES.saturating_add(1) - line.len();
+        let read_length = buffer.len().min(remaining_capacity);
+        stream
+            .set_read_timeout(Some(deadline.remaining()?))
+            .map_err(|error| deadline.io_error(error, "read daemon response failed"))?;
+        let read = match stream.read(&mut buffer[..read_length]) {
+            Ok(0) => break,
+            Ok(read) => read,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(error) => {
+                return Err(deadline.io_error(error, "read daemon response failed"));
+            }
+        };
+        if let Some(newline) = buffer[..read].iter().position(|byte| *byte == b'\n') {
+            line.extend_from_slice(&buffer[..=newline]);
+            break;
+        }
+        line.extend_from_slice(&buffer[..read]);
+        if line.len() > MAX_RESPONSE_BYTES {
+            break;
+        }
+    }
+    deadline.remaining()?;
     if line.is_empty() {
         return Err(ManagerError::ForwardingFailed {
             message: "daemon returned an empty response".to_owned(),
@@ -128,6 +163,54 @@ where
     sandbox_protocol::decode_response_line(&line).map_err(|error| ManagerError::ForwardingFailed {
         message: format!("decode daemon response failed: {error}"),
     })
+}
+
+struct RequestDeadline {
+    started_at: Instant,
+    timeout: Duration,
+}
+
+impl RequestDeadline {
+    fn new(timeout: Duration) -> Self {
+        Self {
+            started_at: Instant::now(),
+            timeout,
+        }
+    }
+
+    fn remaining(&self) -> Result<Duration, ManagerError> {
+        let remaining = self.timeout.saturating_sub(self.started_at.elapsed());
+        if remaining.is_zero() {
+            return Err(self.timeout_error());
+        }
+        Ok(remaining)
+    }
+
+    fn is_timeout(&self, error: &io::Error) -> bool {
+        matches!(
+            error.kind(),
+            io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+        ) || self.started_at.elapsed() >= self.timeout
+    }
+
+    fn io_error(&self, error: io::Error, context: impl std::fmt::Display) -> ManagerError {
+        if self.is_timeout(&error) {
+            self.timeout_error()
+        } else {
+            ManagerError::ForwardingFailed {
+                message: format!("{context}: {error}"),
+            }
+        }
+    }
+
+    fn timeout_error(&self) -> ManagerError {
+        ManagerError::ForwardingFailed {
+            message: format!(
+                "daemon request timed out after {} ms",
+                self.timeout.as_millis()
+            ),
+        }
+    }
 }
 
 fn request_line(request: &OperationRequest, auth_token: &str) -> Result<Vec<u8>, ManagerError> {

--- a/crates/sandbox-gateway/src/gateway/config.rs
+++ b/crates/sandbox-gateway/src/gateway/config.rs
@@ -1,8 +1,9 @@
 use std::path::PathBuf;
 
 pub use sandbox_config::configs::gateway::{
-    GatewayConfig, DEFAULT_GATEWAY_PID, DEFAULT_GATEWAY_SOCKET, DEFAULT_MAX_CONCURRENT_CONNECTIONS,
-    SANDBOX_GATEWAY_AUTH_TOKEN_ENV, SANDBOX_GATEWAY_SOCKET_ENV,
+    GatewayConfig, GatewayEndpoint, GatewayEndpointParseError, DEFAULT_GATEWAY_PID,
+    DEFAULT_GATEWAY_SOCKET, DEFAULT_MAX_CONCURRENT_CONNECTIONS, SANDBOX_GATEWAY_AUTH_TOKEN_ENV,
+    SANDBOX_GATEWAY_SOCKET_ENV,
 };
 
 /// CLI-flag overrides for the gateway server; `None` means the flag was not

--- a/crates/sandbox-gateway/src/gateway/lifecycle.rs
+++ b/crates/sandbox-gateway/src/gateway/lifecycle.rs
@@ -1,20 +1,23 @@
 use std::sync::Arc;
 
 use tokio::io::{AsyncWrite, AsyncWriteExt};
-use tokio::net::TcpListener;
 use tokio::sync::Semaphore;
 
+use super::listener::GatewayListener;
 use super::{error, GatewayError, SandboxGatewayServer};
 
 impl SandboxGatewayServer {
     pub async fn serve(self) -> Result<(), GatewayError> {
         let server = Arc::new(self);
         prepare_paths(&server).await?;
-        let listener = TcpListener::bind(server.config.bind_addr.as_str()).await?;
+        let endpoint = server.config.endpoint().map_err(|error| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, error.to_string())
+        })?;
+        let mut listener =
+            GatewayListener::bind(endpoint, server.config.max_concurrent_connections).await?;
         tokio::fs::write(&server.config.pid_path, std::process::id().to_string()).await?;
-
         let permits = Arc::new(Semaphore::new(server.config.max_concurrent_connections));
-        let result = accept_until_shutdown(Arc::clone(&server), listener, permits).await;
+        let result = accept_until_shutdown(Arc::clone(&server), &mut listener, permits).await;
         cleanup_paths(&server).await;
         result
     }
@@ -29,14 +32,14 @@ async fn prepare_paths(server: &SandboxGatewayServer) -> Result<(), GatewayError
 
 async fn accept_until_shutdown(
     server: Arc<SandboxGatewayServer>,
-    listener: TcpListener,
+    listener: &mut GatewayListener,
     permits: Arc<Semaphore>,
 ) -> Result<(), GatewayError> {
     loop {
         tokio::select! {
             () = server.shutdown.cancelled() => return Ok(()),
             accepted = listener.accept() => {
-                let (stream, _) = accepted?;
+                let stream = accepted?;
                 let Ok(permit) = Arc::clone(&permits).try_acquire_owned() else {
                     tokio::spawn(reject_overloaded_connection(
                         stream,

--- a/crates/sandbox-gateway/src/gateway/listener.rs
+++ b/crates/sandbox-gateway/src/gateway/listener.rs
@@ -1,0 +1,243 @@
+use std::io;
+
+use sandbox_config::configs::gateway::GatewayEndpoint;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::TcpListener;
+
+pub(crate) trait GatewayIo: AsyncRead + AsyncWrite + Unpin + Send {}
+
+impl<T> GatewayIo for T where T: AsyncRead + AsyncWrite + Unpin + Send {}
+
+pub(crate) type GatewayStream = Box<dyn GatewayIo>;
+
+pub(crate) enum GatewayListener {
+    Tcp(TcpListener),
+    #[cfg(windows)]
+    WindowsNamedPipe(windows::WindowsNamedPipeListener),
+    #[cfg(unix)]
+    UnixSocket(unix::UnixSocketListener),
+}
+
+impl GatewayListener {
+    pub(crate) async fn bind(
+        endpoint: GatewayEndpoint,
+        max_connections: usize,
+    ) -> io::Result<Self> {
+        match endpoint {
+            GatewayEndpoint::Tcp(address) => Ok(Self::Tcp(TcpListener::bind(address).await?)),
+            GatewayEndpoint::WindowsNamedPipe(path) => {
+                #[cfg(windows)]
+                {
+                    Ok(Self::WindowsNamedPipe(
+                        windows::WindowsNamedPipeListener::bind(path, max_connections)?,
+                    ))
+                }
+                #[cfg(not(windows))]
+                {
+                    let _ = (path, max_connections);
+                    Err(unsupported_transport("npipe"))
+                }
+            }
+            GatewayEndpoint::UnixSocket(path) => {
+                #[cfg(unix)]
+                {
+                    Ok(Self::UnixSocket(unix::UnixSocketListener::bind(path)?))
+                }
+                #[cfg(not(unix))]
+                {
+                    let _ = (path, max_connections);
+                    Err(unsupported_transport("unix"))
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn accept(&mut self) -> io::Result<GatewayStream> {
+        match self {
+            Self::Tcp(listener) => {
+                let (stream, _) = listener.accept().await?;
+                Ok(Box::new(stream))
+            }
+            #[cfg(windows)]
+            Self::WindowsNamedPipe(listener) => listener.accept().await,
+            #[cfg(unix)]
+            Self::UnixSocket(listener) => listener.accept().await,
+        }
+    }
+}
+
+fn unsupported_transport(scheme: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::Unsupported,
+        format!("{scheme} gateway endpoints are unsupported on this platform"),
+    )
+}
+
+#[cfg(windows)]
+mod windows {
+    use std::io;
+    use std::time::Duration;
+
+    use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
+    use tokio::task::JoinSet;
+
+    use super::GatewayStream;
+
+    const MIN_PENDING_INSTANCES: usize = 8;
+    const MAX_PENDING_INSTANCES: usize = 32;
+    const ERROR_PIPE_BUSY: i32 = 231;
+
+    pub(crate) struct WindowsNamedPipeListener {
+        path: String,
+        pending_target: usize,
+        pending: JoinSet<io::Result<NamedPipeServer>>,
+    }
+
+    impl WindowsNamedPipeListener {
+        pub(super) fn bind(path: String, max_connections: usize) -> io::Result<Self> {
+            let pending_target = max_connections
+                .saturating_add(1)
+                .clamp(MIN_PENDING_INSTANCES, MAX_PENDING_INSTANCES);
+            let mut listener = Self {
+                path,
+                pending_target,
+                pending: JoinSet::new(),
+            };
+            let first = listener.create_instance(true)?;
+            listener.spawn_pending(first);
+            listener.replenish()?;
+            Ok(listener)
+        }
+
+        pub(super) async fn accept(&mut self) -> io::Result<GatewayStream> {
+            loop {
+                match self.replenish() {
+                    Ok(()) => {}
+                    Err(error)
+                        if error.raw_os_error() == Some(ERROR_PIPE_BUSY)
+                            && !self.pending.is_empty() => {}
+                    Err(error) if error.raw_os_error() == Some(ERROR_PIPE_BUSY) => {
+                        tokio::time::sleep(Duration::from_millis(1)).await;
+                        continue;
+                    }
+                    Err(error) => return Err(error),
+                }
+                let joined = self.pending.join_next().await.ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::BrokenPipe, "named-pipe listener stopped")
+                })?;
+                let stream = joined.map_err(|error| {
+                    io::Error::other(format!("named-pipe accept task failed: {error}"))
+                })??;
+                return Ok(Box::new(stream));
+            }
+        }
+
+        fn replenish(&mut self) -> io::Result<()> {
+            while self.pending.len() < self.pending_target {
+                let instance = self.create_instance(false)?;
+                self.spawn_pending(instance);
+            }
+            Ok(())
+        }
+
+        fn create_instance(&mut self, first: bool) -> io::Result<NamedPipeServer> {
+            let mut options = ServerOptions::new();
+            options
+                .first_pipe_instance(first)
+                .reject_remote_clients(true);
+            options.create(&self.path)
+        }
+
+        fn spawn_pending(&mut self, instance: NamedPipeServer) {
+            self.pending.spawn(async move {
+                instance.connect().await?;
+                Ok(instance)
+            });
+        }
+    }
+}
+
+#[cfg(unix)]
+mod unix {
+    use std::fs;
+    use std::io;
+    use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
+    use std::path::PathBuf;
+
+    use tokio::net::UnixListener;
+
+    use super::GatewayStream;
+
+    pub(crate) struct UnixSocketListener {
+        listener: UnixListener,
+        path: PathBuf,
+        identity: SocketIdentity,
+    }
+
+    impl UnixSocketListener {
+        pub(super) fn bind(path: PathBuf) -> io::Result<Self> {
+            match fs::symlink_metadata(&path) {
+                Ok(_) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::AlreadyExists,
+                        format!("gateway Unix socket already exists: {}", path.display()),
+                    ));
+                }
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+            let listener = UnixListener::bind(&path)?;
+            if let Err(error) = fs::set_permissions(&path, fs::Permissions::from_mode(0o600)) {
+                let _ = fs::remove_file(&path);
+                return Err(error);
+            }
+            let metadata = fs::symlink_metadata(&path)?;
+            let identity = SocketIdentity::from_metadata(&metadata)?;
+            Ok(Self {
+                listener,
+                path,
+                identity,
+            })
+        }
+
+        pub(super) async fn accept(&self) -> io::Result<GatewayStream> {
+            let (stream, _) = self.listener.accept().await?;
+            Ok(Box::new(stream))
+        }
+    }
+
+    impl Drop for UnixSocketListener {
+        fn drop(&mut self) {
+            let Ok(metadata) = fs::symlink_metadata(&self.path) else {
+                return;
+            };
+            let Ok(identity) = SocketIdentity::from_metadata(&metadata) else {
+                return;
+            };
+            if identity == self.identity {
+                let _ = fs::remove_file(&self.path);
+            }
+        }
+    }
+
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    struct SocketIdentity {
+        device: u64,
+        inode: u64,
+    }
+
+    impl SocketIdentity {
+        fn from_metadata(metadata: &fs::Metadata) -> io::Result<Self> {
+            if !metadata.file_type().is_socket() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "gateway endpoint is not a Unix socket",
+                ));
+            }
+            Ok(Self {
+                device: metadata.dev(),
+                inode: metadata.ino(),
+            })
+        }
+    }
+}

--- a/crates/sandbox-gateway/src/gateway/main.rs
+++ b/crates/sandbox-gateway/src/gateway/main.rs
@@ -42,7 +42,11 @@ enum Backend {
 
 #[derive(Debug, Args)]
 struct ServeCommand {
-    #[arg(long = "gateway-socket", value_name = "HOST:PORT")]
+    #[arg(
+        long = "gateway-endpoint",
+        visible_alias = "gateway-socket",
+        value_name = "ENDPOINT"
+    )]
     gateway_socket: Option<String>,
 
     #[arg(long = "auth-token", value_name = "TOKEN")]

--- a/crates/sandbox-gateway/src/gateway/main.rs
+++ b/crates/sandbox-gateway/src/gateway/main.rs
@@ -1,10 +1,12 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::Arc;
+use std::time::Duration;
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use sandbox_config::configs::{
-    daemon::DaemonConfig, manager::ManagerConfig, runtime::RuntimeConfig,
+    daemon::DaemonConfig, manager::ManagerConfig, observability::ObservabilityConfig,
+    runtime::RuntimeConfig,
 };
 use sandbox_config::ConfigDocument;
 use sandbox_gateway::{
@@ -144,6 +146,12 @@ fn build_docker_services(
     daemon_config.validate()?;
     let runtime_config: RuntimeConfig = document.section("runtime")?;
     runtime_config.validate()?;
+    let observability_config = match document.section::<ObservabilityConfig>("observability") {
+        Ok(section) => section,
+        Err(sandbox_config::ConfigError::MissingSection { .. }) => ObservabilityConfig::default(),
+        Err(error) => return Err(error.into()),
+    };
+    observability_config.validate()?;
     if let Some(docker) = manager_config.docker.as_ref() {
         docker.validate_daemon_runtime_profile(&daemon_config, &runtime_config)?;
     }
@@ -192,7 +200,9 @@ fn build_docker_services(
     services.export_caps = export_caps;
     services.snapshot_limits = snapshot_limits;
     services.workspace_roots = workspace_roots;
-    services.start_resource_sampler();
+    services.start_resource_sampler(Duration::from_millis(
+        observability_config.resource_stats.sample_interval_ms,
+    ));
     Ok(Arc::new(services))
 }
 

--- a/crates/sandbox-gateway/src/gateway/mod.rs
+++ b/crates/sandbox-gateway/src/gateway/mod.rs
@@ -2,12 +2,13 @@ pub mod config;
 pub mod connection;
 pub mod error;
 pub mod lifecycle;
+mod listener;
 pub mod server;
 
 pub use config::{
-    resolve_gateway_config, GatewayCliOverrides, GatewayConfig, DEFAULT_GATEWAY_PID,
-    DEFAULT_GATEWAY_SOCKET, DEFAULT_MAX_CONCURRENT_CONNECTIONS, SANDBOX_GATEWAY_AUTH_TOKEN_ENV,
-    SANDBOX_GATEWAY_SOCKET_ENV,
+    resolve_gateway_config, GatewayCliOverrides, GatewayConfig, GatewayEndpoint,
+    GatewayEndpointParseError, DEFAULT_GATEWAY_PID, DEFAULT_GATEWAY_SOCKET,
+    DEFAULT_MAX_CONCURRENT_CONNECTIONS, SANDBOX_GATEWAY_AUTH_TOKEN_ENV, SANDBOX_GATEWAY_SOCKET_ENV,
 };
 pub use error::GatewayError;
 pub use server::SandboxGatewayServer;

--- a/crates/sandbox-gateway/src/lib.rs
+++ b/crates/sandbox-gateway/src/lib.rs
@@ -7,8 +7,9 @@ mod local_daemon_installer;
 
 pub use daemon_client::TcpSandboxDaemonClient;
 pub use gateway::{
-    resolve_gateway_config, GatewayCliOverrides, GatewayConfig, GatewayError, SandboxGatewayServer,
-    DEFAULT_GATEWAY_PID, DEFAULT_GATEWAY_SOCKET, DEFAULT_MAX_CONCURRENT_CONNECTIONS,
-    SANDBOX_GATEWAY_AUTH_TOKEN_ENV, SANDBOX_GATEWAY_SOCKET_ENV,
+    resolve_gateway_config, GatewayCliOverrides, GatewayConfig, GatewayEndpoint,
+    GatewayEndpointParseError, GatewayError, SandboxGatewayServer, DEFAULT_GATEWAY_PID,
+    DEFAULT_GATEWAY_SOCKET, DEFAULT_MAX_CONCURRENT_CONNECTIONS, SANDBOX_GATEWAY_AUTH_TOKEN_ENV,
+    SANDBOX_GATEWAY_SOCKET_ENV,
 };
 pub use local_daemon_installer::{LocalDaemonTimeouts, LocalSandboxDaemonInstaller};

--- a/crates/sandbox-gateway/tests/daemon_client.rs
+++ b/crates/sandbox-gateway/tests/daemon_client.rs
@@ -1,11 +1,48 @@
-use std::net::TcpListener;
+use std::io::{BufRead, BufReader, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::Duration;
 
 use sandbox_gateway::TcpSandboxDaemonClient;
 use sandbox_manager::{SandboxDaemonClient, SandboxDaemonEndpoint};
-use sandbox_operation_contract::{OperationRequest, OperationScope};
-use serde_json::json;
+use sandbox_operation_contract::{OperationRequest, OperationResponse, OperationScope};
+use sandbox_protocol::{ProtocolLimits, DAEMON_AUTH_FIELD};
+use serde_json::{json, Value};
+
+#[test]
+fn successful_exchange_preserves_authenticated_newline_framing() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+    let port = listener.local_addr().expect("listener address").port();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept daemon client");
+        let request = read_request(&mut stream);
+        let response =
+            sandbox_protocol::response_line(&OperationResponse::from_json_value(json!({
+                "status": "ok",
+                "request_id": request["request_id"],
+            })));
+        stream.write_all(&response).expect("write daemon response");
+        request
+    });
+
+    let response = TcpSandboxDaemonClient::new()
+        .invoke(
+            &SandboxDaemonEndpoint::new("127.0.0.1", port, "token"),
+            operation_request("request-success"),
+            Some(Duration::from_secs(1)),
+        )
+        .expect("daemon exchange succeeds");
+
+    assert_eq!(
+        response.into_json_value(),
+        json!({"status": "ok", "request_id": "request-success"})
+    );
+    let captured_request = server.join().expect("daemon server thread");
+    assert_eq!(captured_request["op"], "run_command");
+    assert_eq!(captured_request["request_id"], "request-success");
+    assert_eq!(captured_request[DAEMON_AUTH_FIELD], "token");
+}
 
 #[test]
 fn explicit_timeout_bounds_stalled_daemon_response() {
@@ -15,17 +52,11 @@ fn explicit_timeout_bounds_stalled_daemon_response() {
         let (_stream, _) = listener.accept().expect("accept daemon client");
         thread::sleep(Duration::from_millis(100));
     });
-    let request = OperationRequest::new(
-        "run_command",
-        "request-1",
-        OperationScope::sandbox("sandbox-1"),
-        json!({}),
-    );
 
     let error = TcpSandboxDaemonClient::new()
         .invoke(
             &SandboxDaemonEndpoint::new("127.0.0.1", port, "token"),
-            request,
+            operation_request("request-timeout"),
             Some(Duration::from_millis(20)),
         )
         .expect_err("stalled daemon response must time out");
@@ -35,4 +66,175 @@ fn explicit_timeout_bounds_stalled_daemon_response() {
         "sandbox daemon forwarding failed: daemon request timed out after 20 ms"
     );
     server.join().expect("daemon server thread");
+}
+
+#[test]
+fn total_timeout_bounds_drip_fed_response() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+    let port = listener.local_addr().expect("listener address").port();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept daemon client");
+        read_request(&mut stream);
+        stream
+            .set_nodelay(true)
+            .expect("disable response buffering");
+        for _ in 0..12 {
+            if stream.write_all(b" ").is_err() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+    });
+
+    let error = TcpSandboxDaemonClient::new()
+        .invoke(
+            &SandboxDaemonEndpoint::new("127.0.0.1", port, "token"),
+            operation_request("request-drip-timeout"),
+            Some(Duration::from_millis(30)),
+        )
+        .expect_err("partial response progress must not reset total timeout");
+
+    assert_eq!(
+        error.to_string(),
+        "sandbox daemon forwarding failed: daemon request timed out after 30 ms"
+    );
+    server.join().expect("daemon server thread");
+}
+
+#[test]
+fn non_newline_terminated_response_is_rejected() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+    let port = listener.local_addr().expect("listener address").port();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept daemon client");
+        read_request(&mut stream);
+        stream
+            .write_all(br#"{"status":"ok"}"#)
+            .expect("write daemon response");
+    });
+
+    let error = TcpSandboxDaemonClient::new()
+        .invoke(
+            &SandboxDaemonEndpoint::new("127.0.0.1", port, "token"),
+            operation_request("request-non-newline"),
+            Some(Duration::from_secs(1)),
+        )
+        .expect_err("non-newline response must fail");
+
+    assert_eq!(
+        error.to_string(),
+        "sandbox daemon forwarding failed: daemon response was not newline terminated"
+    );
+    server.join().expect("daemon server thread");
+}
+
+#[test]
+fn oversized_response_is_rejected_at_protocol_limit() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+    let port = listener.local_addr().expect("listener address").port();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept daemon client");
+        read_request(&mut stream);
+        stream
+            .write_all(&vec![b'a'; ProtocolLimits::DEFAULT_MAX_REQUEST_BYTES + 1])
+            .expect("write oversized daemon response");
+    });
+
+    let error = TcpSandboxDaemonClient::new()
+        .invoke(
+            &SandboxDaemonEndpoint::new("127.0.0.1", port, "token"),
+            operation_request("request-oversized"),
+            Some(Duration::from_secs(5)),
+        )
+        .expect_err("oversized response must fail");
+
+    assert_eq!(
+        error.to_string(),
+        format!(
+            "sandbox daemon forwarding failed: daemon response exceeded {} bytes",
+            ProtocolLimits::DEFAULT_MAX_REQUEST_BYTES
+        )
+    );
+    server.join().expect("daemon server thread");
+}
+
+#[test]
+fn concurrent_calls_remain_independent() {
+    const CALL_COUNT: usize = 8;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+    let port = listener.local_addr().expect("listener address").port();
+    let server = thread::spawn(move || {
+        let mut workers = Vec::with_capacity(CALL_COUNT);
+        for _ in 0..CALL_COUNT {
+            let (mut stream, _) = listener.accept().expect("accept daemon client");
+            workers.push(thread::spawn(move || {
+                let request = read_request(&mut stream);
+                let request_id = request["request_id"]
+                    .as_str()
+                    .expect("request id string")
+                    .to_owned();
+                let response =
+                    sandbox_protocol::response_line(&OperationResponse::from_json_value(json!({
+                        "request_id": request_id,
+                    })));
+                stream.write_all(&response).expect("write daemon response");
+                request
+            }));
+        }
+        workers
+            .into_iter()
+            .map(|worker| worker.join().expect("daemon worker thread"))
+            .collect::<Vec<_>>()
+    });
+    let client = Arc::new(TcpSandboxDaemonClient::new());
+    let endpoint = Arc::new(SandboxDaemonEndpoint::new("127.0.0.1", port, "token"));
+    let barrier = Arc::new(Barrier::new(CALL_COUNT + 1));
+    let callers = (0..CALL_COUNT)
+        .map(|index| {
+            let client = Arc::clone(&client);
+            let endpoint = Arc::clone(&endpoint);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                let request_id = format!("request-concurrent-{index}");
+                barrier.wait();
+                let response = client
+                    .invoke(
+                        &endpoint,
+                        operation_request(&request_id),
+                        Some(Duration::from_secs(2)),
+                    )
+                    .expect("concurrent daemon exchange succeeds");
+                assert_eq!(response.into_json_value()["request_id"], request_id);
+            })
+        })
+        .collect::<Vec<_>>();
+
+    barrier.wait();
+    for caller in callers {
+        caller.join().expect("daemon caller thread");
+    }
+    let captured_requests = server.join().expect("daemon server thread");
+    assert_eq!(captured_requests.len(), CALL_COUNT);
+    assert!(captured_requests
+        .iter()
+        .all(|request| request[DAEMON_AUTH_FIELD] == "token"));
+}
+
+fn operation_request(request_id: &str) -> OperationRequest {
+    OperationRequest::new(
+        "run_command",
+        request_id,
+        OperationScope::sandbox("sandbox-1"),
+        json!({}),
+    )
+}
+
+fn read_request(stream: &mut TcpStream) -> Value {
+    let mut line = Vec::new();
+    BufReader::new(stream)
+        .read_until(b'\n', &mut line)
+        .expect("read daemon request");
+    assert!(line.ends_with(b"\n"));
+    serde_json::from_slice(&line).expect("decode daemon request")
 }

--- a/crates/sandbox-gateway/tests/gateway_server.rs
+++ b/crates/sandbox-gateway/tests/gateway_server.rs
@@ -16,6 +16,10 @@ use sandbox_protocol::{error as wire_error, ProtocolLimits};
 use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
+#[cfg(unix)]
+use tokio::net::UnixStream;
+#[cfg(windows)]
+use tokio::{net::windows::named_pipe::ClientOptions, sync::Barrier, task::JoinSet};
 use tokio_util::sync::CancellationToken;
 
 type TestResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
@@ -253,6 +257,139 @@ async fn gateway_binds_tcp_writes_pid_file_and_cleans_up() -> TestResult {
     Ok(())
 }
 
+#[cfg(windows)]
+#[tokio::test]
+async fn gateway_named_pipe_accepts_concurrent_clients_without_retries() -> TestResult {
+    let root = unique_temp_dir("sandbox-gateway-pipe-test")?;
+    let pid_path = root.join("gateway.pid");
+    let sequence = TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pipe_name = format!("ephemeral-sandbox-test-{}-{sequence}", std::process::id());
+    let endpoint = format!("npipe://./pipe/{pipe_name}");
+    let native_path = format!(r"\\.\pipe\{pipe_name}");
+    let shutdown = CancellationToken::new();
+    let (services, _store, _daemon_client) = services();
+    let server = SandboxGatewayServer::with_shutdown(
+        GatewayConfig::new(endpoint, pid_path.clone(), 8, Some("pipe-token".to_owned())),
+        SandboxManagerRouter::new(services),
+        shutdown.clone(),
+    );
+    let handle = tokio::spawn(server.serve());
+
+    wait_for_path(&pid_path).await?;
+    let barrier = Arc::new(Barrier::new(6));
+    let mut clients = JoinSet::new();
+    for request_id in 0..5 {
+        let barrier = Arc::clone(&barrier);
+        let native_path = native_path.clone();
+        clients.spawn(async move {
+            barrier.wait().await;
+            let mut stream = ClientOptions::new().open(native_path)?;
+            let request = json!({
+                "op": "list_sandboxes",
+                "request_id": format!("pipe-{request_id}"),
+                "scope": OperationScope::System,
+                "args": {},
+                "_sandbox_gateway_auth_token": "pipe-token",
+            });
+            let mut raw = serde_json::to_vec(&request)?;
+            raw.push(b'\n');
+            stream.write_all(&raw).await?;
+            let mut response = String::new();
+            BufReader::new(stream).read_line(&mut response).await?;
+            Ok::<Value, Box<dyn std::error::Error + Send + Sync>>(serde_json::from_str(&response)?)
+        });
+    }
+    barrier.wait().await;
+
+    while let Some(result) = clients.join_next().await {
+        let response = result??;
+        assert_eq!(response["sandboxes"], json!([]));
+    }
+
+    shutdown.cancel();
+    handle.await??;
+    assert!(!pid_path.exists());
+    let _ = std::fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn gateway_unix_socket_is_owner_only_and_removed_on_shutdown() -> TestResult {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = unique_temp_dir("sandbox-gateway-unix-test")?;
+    let pid_path = root.join("gateway.pid");
+    let socket_path = root.join("gateway.sock");
+    let endpoint = format!("unix://{}", socket_path.display());
+    let shutdown = CancellationToken::new();
+    let (services, _store, _daemon_client) = services();
+    let server = SandboxGatewayServer::with_shutdown(
+        GatewayConfig::new(endpoint, pid_path.clone(), 8, Some("unix-token".to_owned())),
+        SandboxManagerRouter::new(services),
+        shutdown.clone(),
+    );
+    let handle = tokio::spawn(server.serve());
+
+    wait_for_path(&pid_path).await?;
+    assert_eq!(
+        std::fs::metadata(&socket_path)?.permissions().mode() & 0o777,
+        0o600
+    );
+    let mut stream = UnixStream::connect(&socket_path).await?;
+    let request = json!({
+        "op": "list_sandboxes",
+        "request_id": "unix-1",
+        "scope": OperationScope::System,
+        "args": {},
+        "_sandbox_gateway_auth_token": "unix-token",
+    });
+    let mut raw = serde_json::to_vec(&request)?;
+    raw.push(b'\n');
+    stream.write_all(&raw).await?;
+    let mut response = String::new();
+    BufReader::new(stream).read_line(&mut response).await?;
+    assert_eq!(
+        serde_json::from_str::<Value>(&response)?["sandboxes"],
+        json!([])
+    );
+
+    shutdown.cancel();
+    handle.await??;
+    assert!(!pid_path.exists());
+    assert!(!socket_path.exists());
+    let _ = std::fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn gateway_unix_socket_refuses_to_replace_existing_path() -> TestResult {
+    let root = unique_temp_dir("sandbox-gateway-unix-stale-test")?;
+    let socket_path = root.join("gateway.sock");
+    std::fs::write(&socket_path, b"preserve")?;
+    let (services, _store, _daemon_client) = services();
+    let server = server(
+        services,
+        format!("unix://{}", socket_path.display()),
+        root.join("gateway.pid"),
+        8,
+        CancellationToken::new(),
+    );
+
+    let error = server
+        .serve()
+        .await
+        .expect_err("existing path must prevent Unix socket bind");
+    assert!(
+        error.to_string().contains("already exists"),
+        "unexpected error: {error}"
+    );
+    assert_eq!(std::fs::read(&socket_path)?, b"preserve");
+    let _ = std::fs::remove_dir_all(root);
+    Ok(())
+}
+
 #[tokio::test]
 async fn gateway_connection_decodes_request_and_writes_response() -> TestResult {
     let (services, _store, _daemon_client) = services();
@@ -303,9 +440,11 @@ async fn gateway_streams_create_sandbox_progress_before_final_response() -> Test
     assert!(responses
         .iter()
         .any(|response| response.contains("building shared workspace base")));
-    assert!(responses.iter().any(
-        |response| response.contains(&format!("creating runtime sandbox for {workspace_root}"))
-    ));
+    let expected_runtime_progress =
+        serde_json::to_string(&format!("creating runtime sandbox for {workspace_root}"))?;
+    assert!(responses
+        .iter()
+        .any(|response| response.contains(&expected_runtime_progress)));
     let final_response = serde_json::from_str::<Value>(responses.last().expect("final response"))?;
     assert_eq!(final_response["id"], "container-1");
     assert_eq!(

--- a/crates/sandbox-gateway/tests/local_daemon_installer.rs
+++ b/crates/sandbox-gateway/tests/local_daemon_installer.rs
@@ -1,3 +1,5 @@
+#![cfg(unix)]
+
 use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::process::{Child, Command};

--- a/crates/sandbox-manager/src/operations/services.rs
+++ b/crates/sandbox-manager/src/operations/services.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 
 pub(crate) const MAX_RESOURCE_HISTORY_MS: i64 = 600_000;
-const RESOURCE_SAMPLE_INTERVAL: Duration = Duration::from_secs(2);
 
 /// `manager.observability_snapshot` fan-out limits; the gateway overwrites
 /// the default with the configured values before serving.
@@ -65,7 +64,11 @@ impl ManagerServices {
         }
     }
 
-    pub fn start_resource_sampler(&self) {
+    pub fn start_resource_sampler(&self, sample_interval: Duration) {
+        assert!(
+            !sample_interval.is_zero(),
+            "resource sample interval must be non-zero"
+        );
         let mut worker = self
             .resource_sampler
             .lock()
@@ -87,9 +90,7 @@ impl ManagerServices {
                         .wake_lock
                         .lock()
                         .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    let _ = thread_signal
-                        .wake
-                        .wait_timeout(guard, RESOURCE_SAMPLE_INTERVAL);
+                    let _ = thread_signal.wake.wait_timeout(guard, sample_interval);
                 }
             });
         if let Ok(handle) = handle {

--- a/crates/sandbox-mcp/src/config.rs
+++ b/crates/sandbox-mcp/src/config.rs
@@ -16,7 +16,11 @@ pub struct Cli {
     #[arg(long, value_enum)]
     pub set: OperationSet,
 
-    #[arg(long = "gateway-socket", value_name = "HOST:PORT")]
+    #[arg(
+        long = "gateway-endpoint",
+        visible_alias = "gateway-socket",
+        value_name = "URI"
+    )]
     gateway_socket_path: Option<PathBuf>,
 
     #[arg(long = "gateway-auth-token", value_name = "TOKEN")]

--- a/crates/sandbox-mcp/src/lib.rs
+++ b/crates/sandbox-mcp/src/lib.rs
@@ -25,10 +25,7 @@ pub async fn run(
     gateway: GatewayConfig,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let catalog = selected_catalog(set)?;
-    let client = GatewayClient::new(
-        gateway.gateway_socket_path.to_string_lossy().into_owned(),
-        gateway.gateway_auth_token,
-    );
+    let client = GatewayClient::from_endpoint(gateway.gateway_endpoint, gateway.gateway_auth_token);
     let server = SandboxMcpServer::new(set, catalog, client)?;
     let service = server.serve(rmcp::transport::stdio()).await?;
     service.waiting().await?;

--- a/crates/sandbox-observability/query/src/query.rs
+++ b/crates/sandbox-observability/query/src/query.rs
@@ -13,7 +13,12 @@ pub(crate) fn snapshot(
     let Some(context) = input.query_context() else {
         return observability_unconfigured();
     };
-    let mut value = response::snapshot_value(&context, input.observability_snapshot());
+    let resource_context = input.resource_query_context();
+    let mut value = response::snapshot_value(
+        &context,
+        resource_context.as_ref().map(|context| &context.reader),
+        input.observability_snapshot(),
+    );
     if let (Ok(observation), Value::Object(object)) = (input.observe_layerstack(), &mut value) {
         object.insert(
             "stack".to_owned(),

--- a/crates/sandbox-observability/query/src/response.rs
+++ b/crates/sandbox-observability/query/src/response.rs
@@ -9,7 +9,11 @@ use crate::ports::{
     NamespaceExecutionSnapshot, ObservabilitySnapshot, QueryContext, WorkspaceSnapshot,
 };
 
-pub(crate) fn snapshot_value(context: &QueryContext, snapshot: ObservabilitySnapshot) -> Value {
+pub(crate) fn snapshot_value(
+    context: &QueryContext,
+    resource_reader: Option<&Reader>,
+    snapshot: ObservabilitySnapshot,
+) -> Value {
     let ObservabilitySnapshot {
         workspaces,
         active_namespace_executions,
@@ -27,7 +31,9 @@ pub(crate) fn snapshot_value(context: &QueryContext, snapshot: ObservabilitySnap
             .iter()
             .map(|workspace| workspace.workspace_id.as_str()),
     );
-    let latest_samples = context.reader.latest_samples(&scopes);
+    let latest_samples = resource_reader
+        .map(|reader| reader.latest_samples(&scopes))
+        .unwrap_or_default();
     json!({
         "sandbox_id": context.sandbox_id,
         "lifecycle_state": "ready",

--- a/crates/sandbox-observability/query/tests/query.rs
+++ b/crates/sandbox-observability/query/tests/query.rs
@@ -177,13 +177,19 @@ fn system_snapshot_and_unknown_operations_are_not_observability_handlers() {
 
 #[test]
 fn snapshot_renders_neutral_runtime_state_and_latest_resources() {
-    let log_path = log_path("snapshot");
+    let event_log_path = log_path("snapshot-events");
+    let resource_log_path = log_path("snapshot-resources");
     write_lines(
-        &log_path,
+        &event_log_path,
+        &[sample_line("workspace-1", json!({ "disk_bytes": 999 }))],
+    );
+    write_lines(
+        &resource_log_path,
         &[sample_line("workspace-1", json!({ "disk_bytes": 3 }))],
     );
     let input = FakeInput {
-        log_path: Some(log_path),
+        log_path: Some(event_log_path),
+        resource_log_path: Some(resource_log_path),
         snapshot: ObservabilitySnapshot {
             workspaces: vec![
                 workspace("workspace-1", &["l0"]),

--- a/crates/sandbox-operations/client/src/client.rs
+++ b/crates/sandbox-operations/client/src/client.rs
@@ -4,16 +4,17 @@ use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 
-use crate::MAX_REQUEST_BYTES;
+use crate::{GatewayEndpoint, GatewayEndpointParseError, MAX_REQUEST_BYTES};
 
 #[derive(Debug)]
 pub struct GatewayClient {
-    addr: String,
+    endpoint: Result<GatewayEndpoint, GatewayEndpointParseError>,
     auth_token: Option<String>,
 }
 
 #[derive(Debug)]
 pub enum GatewayClientError {
+    Endpoint(GatewayEndpointParseError),
     Transport(std::io::Error),
     Protocol(String),
     Json(serde_json::Error),
@@ -21,9 +22,17 @@ pub enum GatewayClientError {
 
 impl GatewayClient {
     #[must_use]
-    pub fn new(addr: impl Into<String>, auth_token: Option<String>) -> Self {
+    pub fn new(endpoint: impl Into<String>, auth_token: Option<String>) -> Self {
         Self {
-            addr: addr.into(),
+            endpoint: GatewayEndpoint::parse(&endpoint.into()),
+            auth_token,
+        }
+    }
+
+    #[must_use]
+    pub const fn from_endpoint(endpoint: GatewayEndpoint, auth_token: Option<String>) -> Self {
+        Self {
+            endpoint: Ok(endpoint),
             auth_token,
         }
     }
@@ -42,7 +51,11 @@ impl GatewayClient {
         F: FnMut(&str),
     {
         let request_line = request_line(request, self.auth_token.as_deref(), stream_logs)?;
-        let mut stream = TcpStream::connect(self.addr.as_str())
+        let endpoint = self
+            .endpoint
+            .as_ref()
+            .map_err(|error| GatewayClientError::Endpoint(error.clone()))?;
+        let mut stream = connect(endpoint)
             .await
             .map_err(GatewayClientError::Transport)?;
         stream
@@ -65,7 +78,7 @@ impl GatewayClientError {
     #[must_use]
     pub const fn kind(&self) -> &'static str {
         match self {
-            Self::Transport(_) => "connection_error",
+            Self::Endpoint(_) | Self::Transport(_) => "connection_error",
             Self::Protocol(_) | Self::Json(_) => "protocol_error",
         }
     }
@@ -74,6 +87,7 @@ impl GatewayClientError {
 impl std::fmt::Display for GatewayClientError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Endpoint(error) => write!(formatter, "invalid gateway endpoint: {error}"),
             Self::Transport(error) => write!(formatter, "gateway connection failed: {error}"),
             Self::Protocol(message) => formatter.write_str(message),
             Self::Json(error) => write!(formatter, "gateway response json failed: {error}"),
@@ -82,6 +96,54 @@ impl std::fmt::Display for GatewayClientError {
 }
 
 impl std::error::Error for GatewayClientError {}
+
+trait GatewayIo: AsyncRead + tokio::io::AsyncWrite + Unpin + Send {}
+
+impl<T> GatewayIo for T where T: AsyncRead + tokio::io::AsyncWrite + Unpin + Send {}
+
+type GatewayStream = Box<dyn GatewayIo>;
+
+async fn connect(endpoint: &GatewayEndpoint) -> std::io::Result<GatewayStream> {
+    match endpoint {
+        GatewayEndpoint::Tcp(address) => TcpStream::connect(address)
+            .await
+            .map(|stream| Box::new(stream) as GatewayStream),
+        GatewayEndpoint::WindowsNamedPipe(path) => connect_windows_named_pipe(path).await,
+        GatewayEndpoint::UnixSocket(path) => connect_unix_socket(path).await,
+    }
+}
+
+#[cfg(windows)]
+async fn connect_windows_named_pipe(path: &str) -> std::io::Result<GatewayStream> {
+    use tokio::net::windows::named_pipe::ClientOptions;
+
+    ClientOptions::new()
+        .open(path)
+        .map(|stream| Box::new(stream) as GatewayStream)
+}
+
+#[cfg(not(windows))]
+async fn connect_windows_named_pipe(_path: &str) -> std::io::Result<GatewayStream> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "Windows named-pipe gateway endpoints are unavailable on this platform",
+    ))
+}
+
+#[cfg(unix)]
+async fn connect_unix_socket(path: &std::path::Path) -> std::io::Result<GatewayStream> {
+    tokio::net::UnixStream::connect(path)
+        .await
+        .map(|stream| Box::new(stream) as GatewayStream)
+}
+
+#[cfg(not(unix))]
+async fn connect_unix_socket(_path: &std::path::Path) -> std::io::Result<GatewayStream> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "Unix-domain gateway endpoints are unavailable on this platform",
+    ))
+}
 
 fn request_line(
     request: &OperationRequest,

--- a/crates/sandbox-operations/client/src/client.rs
+++ b/crates/sandbox-operations/client/src/client.rs
@@ -108,6 +108,9 @@ async fn connect(endpoint: &GatewayEndpoint) -> std::io::Result<GatewayStream> {
         GatewayEndpoint::Tcp(address) => TcpStream::connect(address)
             .await
             .map(|stream| Box::new(stream) as GatewayStream),
+        GatewayEndpoint::TcpHost(address) => TcpStream::connect(address.as_str())
+            .await
+            .map(|stream| Box::new(stream) as GatewayStream),
         GatewayEndpoint::WindowsNamedPipe(path) => connect_windows_named_pipe(path).await,
         GatewayEndpoint::UnixSocket(path) => connect_unix_socket(path).await,
     }

--- a/crates/sandbox-operations/client/src/config.rs
+++ b/crates/sandbox-operations/client/src/config.rs
@@ -3,13 +3,19 @@
 use std::ffi::OsString;
 use std::path::PathBuf;
 
+use crate::GatewayEndpoint;
+
 pub const SANDBOX_GATEWAY_SOCKET_ENV: &str = "SANDBOX_GATEWAY_SOCKET";
 pub const SANDBOX_GATEWAY_AUTH_TOKEN_ENV: &str = "SANDBOX_GATEWAY_AUTH_TOKEN";
+#[cfg(windows)]
+pub const DEFAULT_GATEWAY_SOCKET: &str = "npipe://./pipe/ephemeral-sandbox-gateway";
+#[cfg(not(windows))]
 pub const DEFAULT_GATEWAY_SOCKET: &str = "127.0.0.1:7878";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GatewayConfig {
     pub gateway_socket_path: PathBuf,
+    pub gateway_endpoint: GatewayEndpoint,
     pub gateway_auth_token: Option<String>,
 }
 
@@ -63,6 +69,8 @@ impl GatewayConfig {
         if gateway_socket_path.as_os_str().is_empty() {
             return Err(config_error("gateway socket path must be non-empty"));
         }
+        let gateway_endpoint = GatewayEndpoint::parse(&gateway_socket_path.to_string_lossy())
+            .map_err(|error| config_error(format!("invalid gateway endpoint: {error}")))?;
 
         let gateway_auth_token = overrides
             .gateway_auth_token
@@ -72,6 +80,7 @@ impl GatewayConfig {
 
         Ok(Self {
             gateway_socket_path,
+            gateway_endpoint,
             gateway_auth_token,
         })
     }

--- a/crates/sandbox-operations/client/src/endpoint.rs
+++ b/crates/sandbox-operations/client/src/endpoint.rs
@@ -10,6 +10,7 @@ const UNIX_SOCKET_SCHEME: &str = "unix://";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GatewayEndpoint {
     Tcp(SocketAddr),
+    TcpHost(String),
     WindowsNamedPipe(String),
     UnixSocket(PathBuf),
 }
@@ -90,6 +91,7 @@ impl std::fmt::Display for GatewayEndpoint {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Tcp(address) => write!(formatter, "{TCP_SCHEME}{address}"),
+            Self::TcpHost(address) => write!(formatter, "{TCP_SCHEME}{address}"),
             Self::WindowsNamedPipe(path) => {
                 let name = path.strip_prefix(WINDOWS_NAMED_PIPE_PREFIX).unwrap_or(path);
                 write!(
@@ -114,13 +116,33 @@ impl std::fmt::Display for GatewayEndpointParseError {
 impl std::error::Error for GatewayEndpointParseError {}
 
 fn parse_tcp_address(value: &str) -> Result<GatewayEndpoint, GatewayEndpointParseError> {
-    let address = value
-        .parse::<SocketAddr>()
-        .map_err(|_| endpoint_error("TCP gateway endpoint must be a valid IP socket address"))?;
-    if address.port() == 0 {
+    if let Ok(address) = value.parse::<SocketAddr>() {
+        if address.port() == 0 {
+            return Err(endpoint_error("TCP gateway endpoint port must be non-zero"));
+        }
+        return Ok(GatewayEndpoint::Tcp(address));
+    }
+    let Some((host, port)) = value.rsplit_once(':') else {
+        return Err(endpoint_error(
+            "TCP gateway endpoint must be a valid host:port address",
+        ));
+    };
+    if host.is_empty()
+        || host
+            .chars()
+            .any(|character| character.is_whitespace() || matches!(character, ':' | '/' | '\\'))
+    {
+        return Err(endpoint_error(
+            "TCP gateway endpoint must be a valid host:port address",
+        ));
+    }
+    let port = port
+        .parse::<u16>()
+        .map_err(|_| endpoint_error("TCP gateway endpoint must be a valid host:port address"))?;
+    if port == 0 {
         return Err(endpoint_error("TCP gateway endpoint port must be non-zero"));
     }
-    Ok(GatewayEndpoint::Tcp(address))
+    Ok(GatewayEndpoint::TcpHost(format!("{host}:{port}")))
 }
 
 fn parse_unix_socket_path(value: &str) -> Result<GatewayEndpoint, GatewayEndpointParseError> {

--- a/crates/sandbox-operations/client/src/endpoint.rs
+++ b/crates/sandbox-operations/client/src/endpoint.rs
@@ -1,0 +1,190 @@
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+const TCP_SCHEME: &str = "tcp://";
+const WINDOWS_NAMED_PIPE_SCHEME: &str = "npipe://./pipe/";
+const WINDOWS_NAMED_PIPE_PREFIX: &str = r"\\.\pipe\";
+const UNIX_SOCKET_SCHEME: &str = "unix://";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GatewayEndpoint {
+    Tcp(SocketAddr),
+    WindowsNamedPipe(String),
+    UnixSocket(PathBuf),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatewayEndpointParseError {
+    message: String,
+}
+
+impl GatewayEndpoint {
+    /// Parse an explicit gateway endpoint URI or a legacy TCP socket address.
+    ///
+    /// # Errors
+    /// Returns an error when the endpoint syntax, address, or path is invalid.
+    pub fn parse(value: &str) -> Result<Self, GatewayEndpointParseError> {
+        value.parse()
+    }
+
+    #[must_use]
+    pub fn tcp(address: SocketAddr) -> Self {
+        Self::Tcp(address)
+    }
+
+    /// Construct a gateway endpoint from a canonical Windows named-pipe path.
+    ///
+    /// # Errors
+    /// Returns an error when the path is outside the local named-pipe namespace.
+    pub fn windows_named_pipe(path: impl Into<String>) -> Result<Self, GatewayEndpointParseError> {
+        let path = path.into();
+        let Some(name) = path.strip_prefix(WINDOWS_NAMED_PIPE_PREFIX) else {
+            return Err(endpoint_error(
+                "Windows named-pipe path must start with \\\\.\\pipe\\",
+            ));
+        };
+        parse_named_pipe_name(name, '\\')
+    }
+
+    /// Construct a gateway endpoint from an absolute Unix-domain socket path.
+    ///
+    /// # Errors
+    /// Returns an error when the path is not absolute or has unsafe segments.
+    pub fn unix_socket(path: impl Into<PathBuf>) -> Result<Self, GatewayEndpointParseError> {
+        let path = path.into();
+        let path_text = path.to_string_lossy();
+        parse_unix_socket_path(&path_text)
+    }
+}
+
+impl FromStr for GatewayEndpoint {
+    type Err = GatewayEndpointParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.is_empty() {
+            return Err(endpoint_error("gateway endpoint must be non-empty"));
+        }
+        if value.trim() != value {
+            return Err(endpoint_error(
+                "gateway endpoint must not contain surrounding whitespace",
+            ));
+        }
+        if let Some(address) = value.strip_prefix(TCP_SCHEME) {
+            return parse_tcp_address(address);
+        }
+        if let Some(name) = value.strip_prefix(WINDOWS_NAMED_PIPE_SCHEME) {
+            return parse_named_pipe_name(name, '/');
+        }
+        if let Some(path) = value.strip_prefix(UNIX_SOCKET_SCHEME) {
+            return parse_unix_socket_path(path);
+        }
+        if value.contains("://") {
+            return Err(endpoint_error("unsupported gateway endpoint scheme"));
+        }
+        parse_tcp_address(value)
+    }
+}
+
+impl std::fmt::Display for GatewayEndpoint {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Tcp(address) => write!(formatter, "{TCP_SCHEME}{address}"),
+            Self::WindowsNamedPipe(path) => {
+                let name = path.strip_prefix(WINDOWS_NAMED_PIPE_PREFIX).unwrap_or(path);
+                write!(
+                    formatter,
+                    "{WINDOWS_NAMED_PIPE_SCHEME}{}",
+                    name.replace('\\', "/")
+                )
+            }
+            Self::UnixSocket(path) => {
+                write!(formatter, "{UNIX_SOCKET_SCHEME}{}", path.display())
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for GatewayEndpointParseError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for GatewayEndpointParseError {}
+
+fn parse_tcp_address(value: &str) -> Result<GatewayEndpoint, GatewayEndpointParseError> {
+    let address = value
+        .parse::<SocketAddr>()
+        .map_err(|_| endpoint_error("TCP gateway endpoint must be a valid IP socket address"))?;
+    if address.port() == 0 {
+        return Err(endpoint_error("TCP gateway endpoint port must be non-zero"));
+    }
+    Ok(GatewayEndpoint::Tcp(address))
+}
+
+fn parse_unix_socket_path(value: &str) -> Result<GatewayEndpoint, GatewayEndpointParseError> {
+    let Some(name) = value.strip_prefix('/') else {
+        return Err(endpoint_error("Unix-domain socket path must be absolute"));
+    };
+    validate_path_segments(name.split('/'), "Unix-domain socket")?;
+    if value.len() > 100 {
+        return Err(endpoint_error(
+            "Unix-domain socket path exceeds the portable 100-byte limit",
+        ));
+    }
+    if value.chars().any(char::is_control) || value.contains('\\') {
+        return Err(endpoint_error(
+            "Unix-domain socket path contains an unsafe character",
+        ));
+    }
+    Ok(GatewayEndpoint::UnixSocket(PathBuf::from(value)))
+}
+
+fn parse_named_pipe_name(
+    name: &str,
+    separator: char,
+) -> Result<GatewayEndpoint, GatewayEndpointParseError> {
+    validate_path_segments(name.split(separator), "Windows named-pipe")?;
+    if name.chars().any(|character| {
+        !character.is_ascii_alphanumeric()
+            && character != separator
+            && !matches!(character, '-' | '_' | '.')
+    }) {
+        return Err(endpoint_error(
+            "Windows named-pipe name contains an unsafe character",
+        ));
+    }
+    let path = format!("{WINDOWS_NAMED_PIPE_PREFIX}{}", name.replace('/', "\\"));
+    if path.encode_utf16().count() > 256 {
+        return Err(endpoint_error(
+            "Windows named-pipe path exceeds the 256-character limit",
+        ));
+    }
+    Ok(GatewayEndpoint::WindowsNamedPipe(path))
+}
+
+fn validate_path_segments<'a>(
+    segments: impl Iterator<Item = &'a str>,
+    transport: &str,
+) -> Result<(), GatewayEndpointParseError> {
+    for segment in segments {
+        if segment.is_empty() {
+            return Err(endpoint_error(format!(
+                "{transport} path must not contain empty segments"
+            )));
+        }
+        if matches!(segment, "." | "..") {
+            return Err(endpoint_error(format!(
+                "{transport} path must not contain dot segments"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn endpoint_error(message: impl Into<String>) -> GatewayEndpointParseError {
+    GatewayEndpointParseError {
+        message: message.into(),
+    }
+}

--- a/crates/sandbox-operations/client/src/lib.rs
+++ b/crates/sandbox-operations/client/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod client;
 mod config;
+mod endpoint;
 mod request;
 
 pub use client::{GatewayClient, GatewayClientError};
@@ -10,6 +11,7 @@ pub use config::{
     ConfigError, GatewayConfig, GatewayConfigOverrides, DEFAULT_GATEWAY_SOCKET,
     SANDBOX_GATEWAY_AUTH_TOKEN_ENV, SANDBOX_GATEWAY_SOCKET_ENV,
 };
+pub use endpoint::{GatewayEndpoint, GatewayEndpointParseError};
 pub use request::{
     build_request_from_values, build_request_from_values_with_id, catalog_arg_default,
     BuildRequestValueInput, RequestBuildError,

--- a/crates/sandbox-operations/client/tests/config.rs
+++ b/crates/sandbox-operations/client/tests/config.rs
@@ -2,8 +2,8 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 
 use sandbox_operation_client::{
-    GatewayConfig, GatewayConfigOverrides, DEFAULT_GATEWAY_SOCKET, SANDBOX_GATEWAY_AUTH_TOKEN_ENV,
-    SANDBOX_GATEWAY_SOCKET_ENV,
+    GatewayConfig, GatewayConfigOverrides, GatewayEndpoint, DEFAULT_GATEWAY_SOCKET,
+    SANDBOX_GATEWAY_AUTH_TOKEN_ENV, SANDBOX_GATEWAY_SOCKET_ENV,
 };
 
 #[test]
@@ -14,23 +14,27 @@ fn config_precedence_is_override_environment_default() {
         default_config.gateway_socket_path,
         PathBuf::from(DEFAULT_GATEWAY_SOCKET)
     );
+    assert_eq!(
+        default_config.gateway_endpoint,
+        GatewayEndpoint::parse(DEFAULT_GATEWAY_SOCKET).expect("default endpoint")
+    );
 
     let env_config =
         GatewayConfig::discover_with(GatewayConfigOverrides::default(), |key| match key {
-            SANDBOX_GATEWAY_SOCKET_ENV => Some(OsString::from("/env/gateway.sock")),
+            SANDBOX_GATEWAY_SOCKET_ENV => Some(OsString::from("unix:///env/gateway.sock")),
             SANDBOX_GATEWAY_AUTH_TOKEN_ENV => Some(OsString::from("env-token")),
             _ => None,
         })
         .expect("environment config discovers");
     assert_eq!(
         env_config.gateway_socket_path,
-        PathBuf::from("/env/gateway.sock")
+        PathBuf::from("unix:///env/gateway.sock")
     );
     assert_eq!(env_config.gateway_auth_token.as_deref(), Some("env-token"));
 
     let override_config = GatewayConfig::discover_with(
         GatewayConfigOverrides {
-            gateway_socket_path: Some(PathBuf::from("/override/gateway.sock")),
+            gateway_socket_path: Some(PathBuf::from("npipe://./pipe/override/gateway")),
             gateway_auth_token: Some("override-token".to_owned()),
         },
         |_| None,
@@ -38,7 +42,7 @@ fn config_precedence_is_override_environment_default() {
     .expect("overrides discover");
     assert_eq!(
         override_config.gateway_socket_path,
-        PathBuf::from("/override/gateway.sock")
+        PathBuf::from("npipe://./pipe/override/gateway")
     );
     assert_eq!(
         override_config.gateway_auth_token.as_deref(),

--- a/crates/sandbox-operations/client/tests/endpoint.rs
+++ b/crates/sandbox-operations/client/tests/endpoint.rs
@@ -1,0 +1,135 @@
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::path::PathBuf;
+
+use sandbox_operation_client::{GatewayEndpoint, GatewayEndpointParseError};
+
+#[test]
+fn parses_explicit_and_legacy_tcp_endpoints() {
+    let ipv4 = SocketAddr::from((Ipv4Addr::LOCALHOST, 7878));
+    let ipv6 = SocketAddr::from((Ipv6Addr::LOCALHOST, 7878));
+
+    assert_eq!(
+        GatewayEndpoint::parse("tcp://127.0.0.1:7878").expect("explicit IPv4"),
+        GatewayEndpoint::Tcp(ipv4)
+    );
+    assert_eq!(
+        GatewayEndpoint::parse("127.0.0.1:7878").expect("legacy IPv4"),
+        GatewayEndpoint::Tcp(ipv4)
+    );
+    assert_eq!(
+        GatewayEndpoint::parse("tcp://[::1]:7878").expect("explicit IPv6"),
+        GatewayEndpoint::Tcp(ipv6)
+    );
+}
+
+#[test]
+fn parses_local_ipc_endpoints_to_native_paths() {
+    let named_pipe =
+        GatewayEndpoint::parse("npipe://./pipe/ephemeral-sandbox/gateway").expect("named pipe");
+    let unix_socket = GatewayEndpoint::parse("unix:///run/user/1000/ephemeral-sandbox.sock")
+        .expect("Unix socket");
+
+    assert_eq!(
+        named_pipe,
+        GatewayEndpoint::WindowsNamedPipe(r"\\.\pipe\ephemeral-sandbox\gateway".to_owned())
+    );
+    assert_eq!(
+        unix_socket,
+        GatewayEndpoint::UnixSocket(PathBuf::from("/run/user/1000/ephemeral-sandbox.sock"))
+    );
+    assert_eq!(
+        named_pipe.to_string(),
+        "npipe://./pipe/ephemeral-sandbox/gateway"
+    );
+    assert_eq!(
+        unix_socket.to_string(),
+        "unix:///run/user/1000/ephemeral-sandbox.sock"
+    );
+}
+
+#[test]
+fn endpoint_constructors_validate_local_paths() {
+    assert_eq!(
+        GatewayEndpoint::windows_named_pipe(r"\\.\pipe\gateway").expect("native pipe"),
+        GatewayEndpoint::WindowsNamedPipe(r"\\.\pipe\gateway".to_owned())
+    );
+    assert_eq!(
+        GatewayEndpoint::unix_socket("/tmp/gateway.sock").expect("absolute Unix path"),
+        GatewayEndpoint::UnixSocket(PathBuf::from("/tmp/gateway.sock"))
+    );
+    assert!(GatewayEndpoint::windows_named_pipe(r"\\.\pipe\gateway/name").is_err());
+}
+
+#[test]
+fn rejects_invalid_endpoint_syntax() {
+    let cases = [
+        ("", "gateway endpoint must be non-empty"),
+        (
+            "http://127.0.0.1:7878",
+            "unsupported gateway endpoint scheme",
+        ),
+        (
+            "tcp://localhost:7878",
+            "TCP gateway endpoint must be a valid IP socket address",
+        ),
+        (
+            "tcp://127.0.0.1:0",
+            "TCP gateway endpoint port must be non-zero",
+        ),
+        (
+            " tcp://127.0.0.1:7878",
+            "gateway endpoint must not contain surrounding whitespace",
+        ),
+        (
+            "npipe://./pipe/gateway/../other",
+            "Windows named-pipe path must not contain dot segments",
+        ),
+        (
+            "npipe://./pipe/gateway:other",
+            "Windows named-pipe name contains an unsafe character",
+        ),
+        (
+            r"npipe://./pipe/gateway\other",
+            "Windows named-pipe name contains an unsafe character",
+        ),
+        (
+            "unix://relative.sock",
+            "Unix-domain socket path must be absolute",
+        ),
+        (
+            "unix:///tmp//gateway.sock",
+            "Unix-domain socket path must not contain empty segments",
+        ),
+        (
+            "unix:///tmp/gateway\\other.sock",
+            "Unix-domain socket path contains an unsafe character",
+        ),
+    ];
+
+    for (value, expected) in cases {
+        let error: GatewayEndpointParseError =
+            GatewayEndpoint::parse(value).expect_err("endpoint is invalid");
+        assert_eq!(error.to_string(), expected);
+    }
+}
+
+#[test]
+fn rejects_local_ipc_paths_over_the_transport_limits() {
+    let pipe_name = "a".repeat(250);
+    let pipe = format!("npipe://./pipe/{pipe_name}");
+    assert_eq!(
+        GatewayEndpoint::parse(&pipe)
+            .expect_err("named-pipe path is too long")
+            .to_string(),
+        "Windows named-pipe path exceeds the 256-character limit"
+    );
+
+    let socket_name = "a".repeat(96);
+    let socket = format!("unix:///tmp/{socket_name}");
+    assert_eq!(
+        GatewayEndpoint::parse(&socket)
+            .expect_err("Unix-domain socket path is too long")
+            .to_string(),
+        "Unix-domain socket path exceeds the portable 100-byte limit"
+    );
+}

--- a/crates/sandbox-operations/client/tests/endpoint.rs
+++ b/crates/sandbox-operations/client/tests/endpoint.rs
@@ -20,6 +20,10 @@ fn parses_explicit_and_legacy_tcp_endpoints() {
         GatewayEndpoint::parse("tcp://[::1]:7878").expect("explicit IPv6"),
         GatewayEndpoint::Tcp(ipv6)
     );
+    assert_eq!(
+        GatewayEndpoint::parse("tcp://localhost:7878").expect("DNS host"),
+        GatewayEndpoint::TcpHost("localhost:7878".to_owned())
+    );
 }
 
 #[test]
@@ -69,8 +73,8 @@ fn rejects_invalid_endpoint_syntax() {
             "unsupported gateway endpoint scheme",
         ),
         (
-            "tcp://localhost:7878",
-            "TCP gateway endpoint must be a valid IP socket address",
+            "tcp://localhost",
+            "TCP gateway endpoint must be a valid host:port address",
         ),
         (
             "tcp://127.0.0.1:0",
@@ -98,6 +102,10 @@ fn rejects_invalid_endpoint_syntax() {
         ),
         (
             "unix:///tmp//gateway.sock",
+            "Unix-domain socket path must not contain empty segments",
+        ),
+        (
+            "unix:////tmp/gateway.sock",
             "Unix-domain socket path must not contain empty segments",
         ),
         (

--- a/crates/sandbox-operations/client/tests/transport.rs
+++ b/crates/sandbox-operations/client/tests/transport.rs
@@ -78,3 +78,169 @@ async fn oversized_encoded_request_is_rejected_before_connection() {
         format!("gateway request exceeded {MAX_REQUEST_BYTES} bytes")
     );
 }
+
+#[tokio::test]
+async fn explicit_tcp_endpoint_uses_the_shared_transport() {
+    let (addr, worker) = gateway(b"{\"transport\":\"tcp\"}\n".to_vec()).await;
+    let client = GatewayClient::new(format!("tcp://{addr}"), None);
+    let response = client.send(&request(json!({}))).await.expect("response");
+    worker.await.expect("gateway task");
+
+    assert_eq!(response, json!({"transport": "tcp"}));
+}
+
+#[tokio::test]
+async fn invalid_endpoint_fails_before_transport_connection() {
+    let client = GatewayClient::new("http://127.0.0.1:7878", None);
+    let error = client
+        .send(&request(json!({})))
+        .await
+        .expect_err("invalid endpoint");
+
+    assert!(matches!(&error, GatewayClientError::Endpoint(_)));
+    assert_eq!(error.kind(), "connection_error");
+    assert_eq!(
+        error.to_string(),
+        "invalid gateway endpoint: unsupported gateway endpoint scheme"
+    );
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn named_pipe_endpoint_round_trips_a_gateway_request() {
+    use sandbox_operation_client::GatewayEndpoint;
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    use tokio::net::windows::named_pipe::ServerOptions;
+
+    let pipe_path = format!(
+        r"\\.\pipe\sandbox-operation-client-{}",
+        uuid::Uuid::new_v4()
+    );
+    let server = ServerOptions::new()
+        .first_pipe_instance(true)
+        .create(&pipe_path)
+        .expect("create named pipe");
+    let worker = tokio::spawn(async move {
+        server.connect().await.expect("connect named-pipe client");
+        let mut reader = BufReader::new(server);
+        let mut request = Vec::new();
+        reader
+            .read_until(b'\n', &mut request)
+            .await
+            .expect("read request");
+        reader
+            .get_mut()
+            .write_all(b"{\"transport\":\"npipe\"}\n")
+            .await
+            .expect("write response");
+        serde_json::from_slice::<Value>(&request).expect("request JSON")
+    });
+    let endpoint = GatewayEndpoint::windows_named_pipe(pipe_path).expect("named-pipe endpoint");
+    let client = GatewayClient::from_endpoint(endpoint, None);
+    let response = client.send(&request(json!({}))).await.expect("response");
+    let received = worker.await.expect("gateway task");
+
+    assert_eq!(response, json!({"transport": "npipe"}));
+    assert_eq!(received["op"], "list_sandboxes");
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn named_pipe_endpoint_handles_concurrency_five_bursts() {
+    use sandbox_operation_client::GatewayEndpoint;
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    use tokio::net::windows::named_pipe::ServerOptions;
+
+    const CLIENTS: usize = 5;
+
+    let pipe_path = format!(
+        r"\\.\pipe\sandbox-operation-client-burst-{}",
+        uuid::Uuid::new_v4()
+    );
+    let first_server = ServerOptions::new()
+        .first_pipe_instance(true)
+        .create(&pipe_path)
+        .expect("create first named-pipe instance");
+    let mut servers = vec![first_server];
+    for _ in 1..CLIENTS {
+        servers.push(
+            ServerOptions::new()
+                .create(&pipe_path)
+                .expect("create pending named-pipe instance"),
+        );
+    }
+    let worker = tokio::spawn(async move {
+        let mut handlers = Vec::with_capacity(CLIENTS);
+        for server in servers {
+            handlers.push(tokio::spawn(async move {
+                server.connect().await.expect("connect named-pipe client");
+                let mut reader = BufReader::new(server);
+                let mut request = Vec::new();
+                reader
+                    .read_until(b'\n', &mut request)
+                    .await
+                    .expect("read request");
+                reader
+                    .get_mut()
+                    .write_all(b"{\"transport\":\"npipe\"}\n")
+                    .await
+                    .expect("write response");
+            }));
+        }
+        for handler in handlers {
+            handler.await.expect("named-pipe handler");
+        }
+    });
+    let endpoint = GatewayEndpoint::windows_named_pipe(pipe_path).expect("named-pipe endpoint");
+    let mut clients = Vec::new();
+    for _ in 0..CLIENTS {
+        let client = GatewayClient::from_endpoint(endpoint.clone(), None);
+        clients.push(tokio::spawn(async move {
+            client.send(&request(json!({}))).await.expect("response")
+        }));
+    }
+    for client in clients {
+        assert_eq!(
+            client.await.expect("client task"),
+            json!({"transport": "npipe"})
+        );
+    }
+    worker.await.expect("gateway task");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn unix_socket_endpoint_round_trips_a_gateway_request() {
+    use sandbox_operation_client::GatewayEndpoint;
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    use tokio::net::UnixListener;
+
+    let socket_path = std::env::temp_dir().join(format!(
+        "sandbox-operation-client-{}.sock",
+        uuid::Uuid::new_v4()
+    ));
+    let listener = UnixListener::bind(&socket_path).expect("bind Unix socket");
+    let worker = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept client");
+        let mut reader = BufReader::new(stream);
+        let mut request = Vec::new();
+        reader
+            .read_until(b'\n', &mut request)
+            .await
+            .expect("read request");
+        reader
+            .get_mut()
+            .write_all(b"{\"transport\":\"unix\"}\n")
+            .await
+            .expect("write response");
+        serde_json::from_slice::<Value>(&request).expect("request JSON")
+    });
+    let endpoint = GatewayEndpoint::unix_socket(&socket_path).expect("Unix endpoint");
+    let client = GatewayClient::from_endpoint(endpoint, None);
+    let response = client.send(&request(json!({}))).await.expect("response");
+    let received = worker.await.expect("gateway task");
+    std::fs::remove_file(&socket_path).expect("remove Unix socket");
+
+    assert_eq!(response, json!({"transport": "unix"}));
+    assert_eq!(received["op"], "list_sandboxes");
+}

--- a/crates/sandbox-operations/client/tests/transport.rs
+++ b/crates/sandbox-operations/client/tests/transport.rs
@@ -90,6 +90,20 @@ async fn explicit_tcp_endpoint_uses_the_shared_transport() {
 }
 
 #[tokio::test]
+async fn legacy_dns_tcp_endpoint_remains_supported() {
+    let (addr, worker) = gateway(b"{\"transport\":\"tcp-dns\"}\n".to_vec()).await;
+    let port = addr
+        .parse::<std::net::SocketAddr>()
+        .expect("fake gateway address")
+        .port();
+    let client = GatewayClient::new(format!("localhost:{port}"), None);
+    let response = client.send(&request(json!({}))).await.expect("response");
+    worker.await.expect("gateway task");
+
+    assert_eq!(response, json!({"transport": "tcp-dns"}));
+}
+
+#[tokio::test]
 async fn invalid_endpoint_fails_before_transport_connection() {
     let client = GatewayClient::new("http://127.0.0.1:7878", None);
     let error = client

--- a/crates/sandbox-provider-docker/Cargo.toml
+++ b/crates/sandbox-provider-docker/Cargo.toml
@@ -18,6 +18,7 @@ uuid.workspace = true
 thiserror.workspace = true
 serde_json.workspace = true
 futures-util.workspace = true
+flate2.workspace = true
 
 [dev-dependencies]
 http-body-util.workspace = true

--- a/crates/sandbox-provider-docker/src/archive.rs
+++ b/crates/sandbox-provider-docker/src/archive.rs
@@ -2,12 +2,13 @@
 //! `put_archive` endpoint. Entries are rooted at `/`, so the archive is
 //! extracted with `path = "/"`.
 
-use std::io;
+use std::io::{self, Write as _};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path};
 
 use bytes::Bytes;
+use flate2::{write::GzEncoder, Compression};
 use sandbox_runtime_layerstack::{
     WorkspaceBinding, ACTIVE_MANIFEST_FILE, LAYERS_DIR, LAYER_METADATA_DIR,
     MANIFEST_SCHEMA_VERSION, SHARED_BASE_DIR, STAGING_DIR, WORKSPACE_BASE_LAYER_ID,
@@ -42,7 +43,10 @@ pub fn build_install_archive(
         config_yaml,
         CONFIG_FILE_MODE,
     )?;
-    let inner = builder.into_inner()?;
+    let archive = builder.into_inner()?;
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+    encoder.write_all(&archive)?;
+    let inner = encoder.finish()?;
     Ok(Bytes::from(inner))
 }
 

--- a/crates/sandbox-provider-docker/src/engine.rs
+++ b/crates/sandbox-provider-docker/src/engine.rs
@@ -1,11 +1,10 @@
-//! Bollard client wrapper plus the async→sync bridge (§4.9). Ordinary operations
-//! use a fresh thread, current-thread Tokio runtime, and Bollard client. The hot
-//! resource-metrics batch path lazily retains one executor so periodic sampling
-//! does not rebuild that stack or cross a worker-thread channel every cycle.
+//! Bollard client wrapper plus the async→sync bridge (§4.9). A lazily retained
+//! executor keeps one Tokio runtime and Bollard client available across calls
+//! while synchronous provider operations wait for their individual result.
 
 use std::collections::HashMap;
 use std::future::Future;
-use std::sync::Mutex;
+use std::sync::{mpsc, Arc, Mutex};
 
 use bollard::container::{
     Config, CreateContainerOptions, ListContainersOptions, LogsOptions, RemoveContainerOptions,
@@ -84,35 +83,39 @@ pub(crate) struct ContainerResourceMetrics {
 
 type ResourceMetricsBatch = Vec<Result<ContainerResourceMetrics, DockerError>>;
 
-struct ResourceMetricsExecutor {
+struct DockerExecutor {
     runtime: tokio::runtime::Runtime,
     docker: Docker,
 }
 
-impl ResourceMetricsExecutor {
+impl DockerExecutor {
     fn start(endpoint: Option<String>, connect_timeout_s: u64) -> Result<Self, DockerError> {
-        let runtime = tokio::runtime::Builder::new_current_thread()
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("docker-engine")
             .enable_all()
             .build()
             .map_err(|error| {
-                DockerError::Connect(format!(
-                    "failed to build docker resource metrics runtime: {error}"
-                ))
+                DockerError::Connect(format!("failed to build docker runtime: {error}"))
             })?;
         let docker = connect(endpoint.as_deref(), connect_timeout_s)?;
         Ok(Self { runtime, docker })
     }
 
-    fn read(&self, containers: Vec<String>) -> Result<ResourceMetricsBatch, DockerError> {
-        Ok(self.runtime.block_on(read_container_resource_metrics_batch(
-            &self.docker,
-            containers,
-        )))
-    }
-
-    #[cfg(test)]
-    fn identity(&self) -> usize {
-        std::ptr::from_ref(self).addr()
+    fn execute<T, F, Fut>(&self, op: F) -> Result<T, DockerError>
+    where
+        T: Send + 'static,
+        F: FnOnce(Docker) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<T, DockerError>> + Send + 'static,
+    {
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let docker = self.docker.clone();
+        self.runtime.spawn(async move {
+            let _ = sender.send(op(docker).await);
+        });
+        receiver
+            .recv()
+            .map_err(|_| DockerError::Api("docker worker task terminated".to_owned()))?
     }
 }
 
@@ -140,14 +143,14 @@ pub(crate) struct RecoveredContainer {
 
 pub(crate) struct DockerEngine {
     config: DockerRuntimeConfig,
-    resource_metrics_executor: Mutex<Option<ResourceMetricsExecutor>>,
+    executor: Mutex<Option<Arc<DockerExecutor>>>,
 }
 
 impl DockerEngine {
     pub(crate) fn new(config: DockerRuntimeConfig) -> Self {
         Self {
             config,
-            resource_metrics_executor: Mutex::new(None),
+            executor: Mutex::new(None),
         }
     }
 
@@ -189,30 +192,22 @@ impl DockerEngine {
     where
         T: Send + 'static,
         F: FnOnce(Docker) -> Fut + Send + 'static,
-        Fut: Future<Output = Result<T, DockerError>>,
+        Fut: Future<Output = Result<T, DockerError>> + Send + 'static,
     {
-        let endpoint = self.config.docker_endpoint.clone();
-        let connect_timeout_s = self.config.connect_timeout_s;
-        let worker = std::thread::Builder::new()
-            .name("docker-engine".to_owned())
-            .spawn(move || {
-                let runtime = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .map_err(|error| {
-                        DockerError::Connect(format!("failed to build docker runtime: {error}"))
-                    })?;
-                runtime.block_on(async move {
-                    let docker = connect(endpoint.as_deref(), connect_timeout_s)?;
-                    op(docker).await
-                })
-            })
-            .map_err(|error| {
-                DockerError::Connect(format!("failed to spawn docker worker: {error}"))
-            })?;
-        worker
-            .join()
-            .map_err(|_| DockerError::Api("docker worker thread panicked".to_owned()))?
+        let executor = {
+            let mut executor = self
+                .executor
+                .lock()
+                .map_err(|_| DockerError::Api("docker executor lock poisoned".to_owned()))?;
+            if executor.is_none() {
+                *executor = Some(Arc::new(DockerExecutor::start(
+                    self.config.docker_endpoint.clone(),
+                    self.config.connect_timeout_s,
+                )?));
+            }
+            Arc::clone(executor.as_ref().expect("docker executor initialized"))
+        };
+        executor.execute(op)
     }
 
     pub(crate) fn create_container(&self, spec: ContainerSpec) -> Result<(), DockerError> {
@@ -302,25 +297,9 @@ impl DockerEngine {
         &self,
         containers: Vec<String>,
     ) -> Result<Vec<Result<ContainerResourceMetrics, DockerError>>, DockerError> {
-        if tokio::runtime::Handle::try_current().is_ok() {
-            return self.run_blocking(move |docker| async move {
-                Ok(read_container_resource_metrics_batch(&docker, containers).await)
-            });
-        }
-
-        let mut executor = self.resource_metrics_executor.lock().map_err(|_| {
-            DockerError::Api("docker resource metrics executor lock poisoned".to_owned())
-        })?;
-        if executor.is_none() {
-            *executor = Some(ResourceMetricsExecutor::start(
-                self.config.docker_endpoint.clone(),
-                self.config.connect_timeout_s,
-            )?);
-        }
-        executor
-            .as_ref()
-            .expect("resource metrics executor initialized")
-            .read(containers)
+        self.run_blocking(move |docker| async move {
+            Ok(read_container_resource_metrics_batch(&docker, containers).await)
+        })
     }
 
     pub(crate) fn seed_volume_from_archive(
@@ -892,67 +871,5 @@ fn server_status(error: &bollard::errors::Error) -> Option<u16> {
     match error {
         bollard::errors::Error::DockerResponseServerError { status_code, .. } => Some(*status_code),
         _ => None,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn resource_metrics_batches_reuse_one_lazy_executor() {
-        let engine = DockerEngine::new(DockerRuntimeConfig::default());
-        assert!(engine
-            .resource_metrics_executor
-            .lock()
-            .expect("resource metrics executor lock")
-            .is_none());
-
-        assert!(engine
-            .container_resource_metrics_batch(Vec::new())
-            .expect("first empty metrics batch")
-            .is_empty());
-        let first_executor = engine
-            .resource_metrics_executor
-            .lock()
-            .expect("resource metrics executor lock")
-            .as_ref()
-            .map(ResourceMetricsExecutor::identity)
-            .expect("resource metrics executor");
-
-        assert!(engine
-            .container_resource_metrics_batch(Vec::new())
-            .expect("second empty metrics batch")
-            .is_empty());
-        let second_executor = engine
-            .resource_metrics_executor
-            .lock()
-            .expect("resource metrics executor lock")
-            .as_ref()
-            .map(ResourceMetricsExecutor::identity)
-            .expect("resource metrics executor");
-
-        assert_eq!(first_executor, second_executor);
-    }
-
-    #[test]
-    fn resource_metrics_batch_uses_safe_fallback_inside_tokio_runtime() {
-        let engine = DockerEngine::new(DockerRuntimeConfig::default());
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("test runtime");
-
-        runtime.block_on(async {
-            assert!(engine
-                .container_resource_metrics_batch(Vec::new())
-                .expect("empty metrics batch inside Tokio runtime")
-                .is_empty());
-        });
-        assert!(engine
-            .resource_metrics_executor
-            .lock()
-            .expect("resource metrics executor lock")
-            .is_none());
     }
 }

--- a/crates/sandbox-provider-docker/src/installer.rs
+++ b/crates/sandbox-provider-docker/src/installer.rs
@@ -5,7 +5,10 @@
 use std::collections::HashSet;
 use std::io::{BufRead as _, BufReader, Write as _};
 use std::net::{Shutdown, TcpStream};
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
+
+use bytes::Bytes;
 
 use crate::archive::build_install_archive;
 use crate::engine::{DockerEngine, DockerError};
@@ -22,6 +25,13 @@ const READINESS_IO_TIMEOUT: Duration = Duration::from_millis(250);
 /// Docker-backed daemon installer.
 pub struct DockerSandboxDaemonInstaller {
     engine: DockerEngine,
+    install_archive: Mutex<Option<CachedInstallArchive>>,
+}
+
+struct CachedInstallArchive {
+    daemon_binary: Vec<u8>,
+    config_yaml: Vec<u8>,
+    archive: Bytes,
 }
 
 impl DockerSandboxDaemonInstaller {
@@ -30,12 +40,11 @@ impl DockerSandboxDaemonInstaller {
     pub fn new(config: DockerRuntimeConfig) -> Self {
         Self {
             engine: DockerEngine::new(config),
+            install_archive: Mutex::new(None),
         }
     }
-}
 
-impl SandboxDaemonInstaller for DockerSandboxDaemonInstaller {
-    fn install_daemon(&self, record: &SandboxRecord) -> Result<(), ManagerError> {
+    fn install_archive(&self) -> Result<Bytes, ManagerError> {
         let config = self.engine.config();
         let daemon_binary = std::fs::read(&config.daemon_binary_path).map_err(|error| {
             daemon_install_failed(format!(
@@ -49,6 +58,14 @@ impl SandboxDaemonInstaller for DockerSandboxDaemonInstaller {
                 config.daemon_config_yaml_path.display()
             ))
         })?;
+        let mut cached = self.install_archive.lock().map_err(|_| {
+            daemon_install_failed("daemon install archive cache lock poisoned".to_owned())
+        })?;
+        if let Some(cached) = cached.as_ref() {
+            if cached.daemon_binary == daemon_binary && cached.config_yaml == config_yaml {
+                return Ok(cached.archive.clone());
+            }
+        }
         let archive = build_install_archive(
             &config.container_daemon_binary_path,
             &daemon_binary,
@@ -56,6 +73,18 @@ impl SandboxDaemonInstaller for DockerSandboxDaemonInstaller {
             &config_yaml,
         )
         .map_err(|error| daemon_install_failed(format!("build install archive: {error}")))?;
+        *cached = Some(CachedInstallArchive {
+            daemon_binary,
+            config_yaml,
+            archive: archive.clone(),
+        });
+        Ok(archive)
+    }
+}
+
+impl SandboxDaemonInstaller for DockerSandboxDaemonInstaller {
+    fn install_daemon(&self, record: &SandboxRecord) -> Result<(), ManagerError> {
+        let archive = self.install_archive()?;
         self.engine
             .upload_archive(
                 record.id.as_str().to_owned(),

--- a/crates/sandbox-provider-docker/tests/archive.rs
+++ b/crates/sandbox-provider-docker/tests/archive.rs
@@ -1,0 +1,55 @@
+use std::collections::HashMap;
+use std::io::Read as _;
+use std::path::Path;
+
+use flate2::read::GzDecoder;
+
+#[allow(dead_code)]
+#[path = "../src/archive.rs"]
+mod archive;
+
+#[test]
+fn install_archive_is_gzip_with_exact_paths_modes_and_bytes() {
+    let daemon = b"daemon-payload";
+    let config = b"runtime:\n  workspace: {}\n";
+    let archive = archive::build_install_archive(
+        Path::new("/eos/bin/sandbox-daemon"),
+        daemon,
+        Path::new("/eos/config/daemon.yml"),
+        config,
+    )
+    .expect("build install archive");
+
+    assert_eq!(&archive[..2], &[0x1f, 0x8b]);
+    let files = archive_files(&archive);
+    assert_eq!(
+        files.get("eos/bin/sandbox-daemon"),
+        Some(&(0o755, daemon.to_vec()))
+    );
+    assert_eq!(
+        files.get("eos/config/daemon.yml"),
+        Some(&(0o644, config.to_vec()))
+    );
+}
+
+fn archive_files(archive: &[u8]) -> HashMap<String, (u32, Vec<u8>)> {
+    let decoder = GzDecoder::new(archive);
+    let mut archive = tar::Archive::new(decoder);
+    let mut files = HashMap::new();
+    for entry in archive.entries().expect("read archive entries") {
+        let mut entry = entry.expect("read archive entry");
+        if !entry.header().entry_type().is_file() {
+            continue;
+        }
+        let path = entry
+            .path()
+            .expect("read archive path")
+            .to_string_lossy()
+            .into_owned();
+        let mode = entry.header().mode().expect("read archive mode");
+        let mut contents = Vec::new();
+        entry.read_to_end(&mut contents).expect("read archive file");
+        files.insert(path, (mode, contents));
+    }
+    files
+}

--- a/crates/sandbox-provider-docker/tests/runtime.rs
+++ b/crates/sandbox-provider-docker/tests/runtime.rs
@@ -253,6 +253,20 @@ fn create_sandbox_rejects_missing_shared_base_source() {
 }
 
 #[test]
+fn repeated_metrics_batches_are_safe_inside_a_tokio_runtime() {
+    let runtime = DockerSandboxRuntime::new(DockerRuntimeConfig::default());
+    let tokio_runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build test runtime");
+
+    tokio_runtime.block_on(async {
+        assert!(runtime.read_sandbox_resource_metrics_batch(&[]).is_empty());
+        assert!(runtime.read_sandbox_resource_metrics_batch(&[]).is_empty());
+    });
+}
+
+#[test]
 #[ignore = "requires a local Docker Engine and the ubuntu:24.04 image"]
 fn create_sandbox_accepts_image_without_git() {
     let root = std::env::temp_dir().join(format!("eos-no-git-sandbox-{}", unique_test_suffix()));

--- a/crates/sandbox-runtime/layerstack/src/workspace_base/build.rs
+++ b/crates/sandbox-runtime/layerstack/src/workspace_base/build.rs
@@ -13,7 +13,9 @@ use super::binding::{
     read_workspace_binding, validate_manifest_for_root, validate_workspace_binding_paths,
     write_workspace_binding_at, WorkspaceBinding,
 };
-use super::layer::{build_base_layer, build_shared_base_layer, SHARED_BASE_DIR};
+use super::layer::{
+    build_base_layer, build_shared_base_layer, hash_shared_base_layer, SHARED_BASE_DIR,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SharedWorkspaceBase {
@@ -133,6 +135,15 @@ pub fn build_shared_workspace_base(
         )));
     }
     std::fs::create_dir_all(cache)?;
+    let snapshot = hash_shared_base_layer(workspace)?;
+    let final_root = cache.join(&snapshot.root_hash);
+    if final_root.exists() {
+        return validated_shared_base_cache_hit(
+            final_root,
+            &snapshot.root_hash,
+            &snapshot.layer_ref.layer_id,
+        );
+    }
     let tmp = cache.join(format!(
         ".building-{}-{}",
         std::process::id(),
@@ -146,16 +157,13 @@ pub fn build_shared_workspace_base(
         let base_layer = build_shared_base_layer(&tmp, workspace)?;
         let root_hash = base_layer.root_hash;
         let final_root = cache.join(&root_hash);
-        let final_base = final_root.join(SHARED_BASE_DIR);
-        if final_base.join(&base_layer.layer_ref.layer_id).is_dir() {
+        if final_root.exists() {
             remove_path(&tmp)?;
-            return Ok(SharedWorkspaceBase {
-                root_hash,
-                cache_entry_root: final_root,
-                base_mount_source: final_base,
-                bytes: 0,
-                built: false,
-            });
+            return validated_shared_base_cache_hit(
+                final_root,
+                &root_hash,
+                &base_layer.layer_ref.layer_id,
+            );
         }
         let _ = std::fs::remove_dir(tmp.join(STAGING_DIR));
         match std::fs::rename(&tmp, &final_root) {
@@ -171,19 +179,11 @@ pub fn build_shared_workspace_base(
             }
             Err(err) if err.kind() == ErrorKind::AlreadyExists => {
                 remove_path(&tmp)?;
-                if !final_base.join(&base_layer.layer_ref.layer_id).is_dir() {
-                    return Err(LayerStackError::Storage(format!(
-                        "shared base cache entry exists but is invalid: {}",
-                        final_root.display()
-                    )));
-                }
-                Ok(SharedWorkspaceBase {
-                    root_hash,
-                    cache_entry_root: final_root,
-                    base_mount_source: final_base,
-                    bytes: 0,
-                    built: false,
-                })
+                validated_shared_base_cache_hit(
+                    final_root,
+                    &root_hash,
+                    &base_layer.layer_ref.layer_id,
+                )
             }
             Err(err) => Err(err.into()),
         }
@@ -192,6 +192,41 @@ pub fn build_shared_workspace_base(
         let _ = remove_path(&tmp);
     }
     result
+}
+
+fn validated_shared_base_cache_hit(
+    cache_entry_root: PathBuf,
+    expected_root_hash: &str,
+    layer_id: &str,
+) -> Result<SharedWorkspaceBase, LayerStackError> {
+    let base_mount_source = cache_entry_root.join(SHARED_BASE_DIR);
+    let layer = base_mount_source.join(layer_id);
+    if !layer.is_dir() {
+        return Err(LayerStackError::Storage(format!(
+            "shared base cache entry is missing its layer directory: {}",
+            layer.display()
+        )));
+    }
+    let cached = hash_shared_base_layer(&layer).map_err(|error| {
+        LayerStackError::Storage(format!(
+            "shared base cache entry could not be validated without mutation: {}: {error}",
+            layer.display()
+        ))
+    })?;
+    if cached.root_hash != expected_root_hash {
+        return Err(LayerStackError::Storage(format!(
+            "shared base cache entry root hash mismatch: expected {expected_root_hash}, observed {} at {}",
+            cached.root_hash,
+            layer.display()
+        )));
+    }
+    Ok(SharedWorkspaceBase {
+        root_hash: expected_root_hash.to_owned(),
+        cache_entry_root,
+        base_mount_source,
+        bytes: 0,
+        built: false,
+    })
 }
 
 fn reject_existing_base_state(stack: &Path) -> Result<(), LayerStackError> {

--- a/crates/sandbox-runtime/layerstack/src/workspace_base/layer.rs
+++ b/crates/sandbox-runtime/layerstack/src/workspace_base/layer.rs
@@ -45,6 +45,19 @@ pub(super) fn build_shared_base_layer(
     build_base_layer_under(stack, workspace, SHARED_BASE_DIR)
 }
 
+pub(super) fn hash_shared_base_layer(workspace: &Path) -> Result<BaseLayerBuild, LayerStackError> {
+    let layer_id = WORKSPACE_BASE_LAYER_ID;
+    let (root_hash, bytes) = read_base_layer(workspace, None)?;
+    Ok(BaseLayerBuild {
+        layer_ref: LayerRef {
+            layer_id: layer_id.to_owned(),
+            path: format!("{SHARED_BASE_DIR}/{layer_id}"),
+        },
+        root_hash,
+        bytes,
+    })
+}
+
 fn build_base_layer_under(
     stack: &Path,
     workspace: &Path,
@@ -61,55 +74,12 @@ fn build_base_layer_under(
     }
     std::fs::create_dir_all(&staging_dir)?;
     let result = (|| {
-        let stats = BuildStats::new();
-        stats.emit(format!(
-            "copying workspace {} into base layer",
-            workspace.display()
-        ));
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(BASE_BUILD_WORKER_THREADS)
-            .build()
-            .map_err(|err| {
-                LayerStackError::Storage(format!("failed to build base-build thread pool: {err}"))
-            })?;
-        let Collected {
-            mut entries,
-            file_tasks,
-            mut special,
-            mut unstable,
-        } = pool.install(|| collect_subtree(workspace, workspace, &staging_dir, &stats))?;
-        merge_file_outcomes(
-            pool.install(|| copy_files(&file_tasks, &stats))?,
-            &mut entries,
-            &mut special,
-            &mut unstable,
-        );
-        if !special.is_empty() || !unstable.is_empty() {
-            special.sort();
-            unstable.sort();
-            stats.emit(format!(
-                "workspace changed or contains unsupported files: special={} unstable={}",
-                special.len(),
-                unstable.len()
-            ));
-            return Err(LayerStackError::Storage(format!(
-                "workspace base must be a full copy; special={} [{}], unstable={} [{}]",
-                special.len(),
-                format_path_sample(&special),
-                unstable.len(),
-                format_path_sample(&unstable)
-            )));
-        }
-        stats.emit(stats.summary());
-        stats.emit(format!("hashing base manifest entries={}", entries.len()));
-        let root_hash = base_root_hash(&mut entries);
-        let bytes = stats.bytes();
-        stats.emit(format!("base manifest root_hash={root_hash}"));
+        let (root_hash, bytes) = read_base_layer(workspace, Some(&staging_dir))?;
         if let Some(parent) = layer_dir.parent() {
             std::fs::create_dir_all(parent)?;
         }
         std::fs::rename(&staging_dir, &layer_dir)?;
-        stats.emit(format!("base layer ready at {}", layer_dir.display()));
+        cli_log(format!("base layer ready at {}", layer_dir.display()));
         Ok::<(String, u64), LayerStackError>((root_hash, bytes))
     })();
     let (root_hash, bytes) = match result {
@@ -130,9 +100,63 @@ fn build_base_layer_under(
     })
 }
 
+fn read_base_layer(
+    workspace: &Path,
+    staging_dir: Option<&Path>,
+) -> Result<(String, u64), LayerStackError> {
+    let stats = BuildStats::new();
+    stats.emit(match staging_dir {
+        Some(_) => format!("copying workspace {} into base layer", workspace.display()),
+        None => format!(
+            "hashing workspace {} for shared base lookup",
+            workspace.display()
+        ),
+    });
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(BASE_BUILD_WORKER_THREADS)
+        .build()
+        .map_err(|err| {
+            LayerStackError::Storage(format!("failed to build base-build thread pool: {err}"))
+        })?;
+    let Collected {
+        mut entries,
+        file_tasks,
+        mut special,
+        mut unstable,
+    } = pool.install(|| collect_subtree(workspace, workspace, staging_dir, &stats))?;
+    merge_file_outcomes(
+        pool.install(|| copy_files(&file_tasks, &stats))?,
+        &mut entries,
+        &mut special,
+        &mut unstable,
+    );
+    if !special.is_empty() || !unstable.is_empty() {
+        special.sort();
+        unstable.sort();
+        stats.emit(format!(
+            "workspace changed or contains unsupported files: special={} unstable={}",
+            special.len(),
+            unstable.len()
+        ));
+        return Err(LayerStackError::Storage(format!(
+            "workspace base must be a full copy; special={} [{}], unstable={} [{}]",
+            special.len(),
+            format_path_sample(&special),
+            unstable.len(),
+            format_path_sample(&unstable)
+        )));
+    }
+    stats.emit(stats.summary());
+    stats.emit(format!("hashing base manifest entries={}", entries.len()));
+    let root_hash = base_root_hash(&mut entries);
+    let bytes = stats.bytes();
+    stats.emit(format!("base manifest root_hash={root_hash}"));
+    Ok((root_hash, bytes))
+}
+
 struct FileTask {
     source: PathBuf,
-    target: PathBuf,
+    target: Option<PathBuf>,
     rel: String,
 }
 
@@ -162,7 +186,7 @@ impl Collected {
 fn collect_subtree(
     workspace: &Path,
     current: &Path,
-    staging_dir: &Path,
+    staging_dir: Option<&Path>,
     stats: &BuildStats,
 ) -> Result<Collected, LayerStackError> {
     let mut collected = Collected::default();
@@ -180,7 +204,7 @@ fn collect_subtree(
     for child in children {
         let source = child.path();
         let rel = relative_path(workspace, &source);
-        let target = join_layer_path(staging_dir, &rel);
+        let target = staging_dir.map(|root| join_layer_path(root, &rel));
         let file_type = match child.file_type() {
             Ok(file_type) => file_type,
             Err(err) if err.kind() == ErrorKind::NotFound => {
@@ -194,14 +218,18 @@ fn collect_subtree(
                 collected.special.push(rel);
                 continue;
             };
-            create_symlink(&link_target, &target)?;
+            if let Some(target) = &target {
+                create_symlink(&link_target, target)?;
+            }
             collected.entries.push(BaseEntry::Symlink {
                 path: rel,
                 link_target: link_target.to_string_lossy().into_owned(),
             });
             stats.record_symlink();
         } else if file_type.is_dir() {
-            std::fs::create_dir_all(&target)?;
+            if let Some(target) = &target {
+                std::fs::create_dir_all(target)?;
+            }
             collected.entries.push(BaseEntry::Directory { path: rel });
             stats.record_directory();
             subdirs.push(source);
@@ -258,7 +286,7 @@ fn merge_file_outcomes(
 }
 
 fn copy_one_file(task: &FileTask, buffer: &mut [u8]) -> Result<FileOutcome, LayerStackError> {
-    match copy_file_with_hash(&task.source, &task.target, buffer) {
+    match copy_file_with_hash(&task.source, task.target.as_deref(), buffer) {
         Ok(copied) => Ok(FileOutcome::Copied(BaseEntry::File {
             path: task.rel.clone(),
             size: copied.size,
@@ -361,13 +389,16 @@ enum CopyFileError {
 
 fn copy_file_with_hash(
     source: &Path,
-    target: &Path,
+    target: Option<&Path>,
     buffer: &mut [u8],
 ) -> Result<CopiedFile, CopyFileError> {
     let mut input = std::fs::File::open(source).map_err(map_source_error)?;
     let metadata = input.metadata().map_err(map_source_error)?;
     let permissions = metadata.permissions();
-    let mut output = std::fs::File::create(target).map_err(CopyFileError::Target)?;
+    let mut output = target
+        .map(std::fs::File::create)
+        .transpose()
+        .map_err(CopyFileError::Target)?;
     let mut digest = Sha256::new();
     let mut size = 0_u64;
 
@@ -378,17 +409,21 @@ fn copy_file_with_hash(
         if count == 0 {
             return Err(CopyFileError::SourceUnreadable);
         }
-        output
-            .write_all(&buffer[..count])
-            .map_err(CopyFileError::Target)?;
+        if let Some(output) = &mut output {
+            output
+                .write_all(&buffer[..count])
+                .map_err(CopyFileError::Target)?;
+        }
         digest.update(&buffer[..count]);
         size += count as u64;
         remaining -= count as u64;
     }
 
-    output
-        .set_permissions(permissions)
-        .map_err(CopyFileError::Target)?;
+    if let Some(output) = output {
+        output
+            .set_permissions(permissions)
+            .map_err(CopyFileError::Target)?;
+    }
     Ok(CopiedFile {
         size,
         content_hash: hex_lower(digest.finalize()),

--- a/crates/sandbox-runtime/layerstack/tests/stack.rs
+++ b/crates/sandbox-runtime/layerstack/tests/stack.rs
@@ -3,9 +3,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use sandbox_runtime_layerstack::MANIFEST_SCHEMA_VERSION;
 use sandbox_runtime_layerstack::{
-    build_workspace_base, ensure_workspace_base, LayerChange, LayerPath, LayerStack,
-    LayerStackError, ManifestFileRead, MergedView, WorkspaceBinding, ACTIVE_MANIFEST_FILE,
-    WORKSPACE_BINDING_FILE,
+    build_shared_workspace_base, build_workspace_base, ensure_workspace_base, LayerChange,
+    LayerPath, LayerStack, LayerStackError, ManifestFileRead, MergedView, WorkspaceBinding,
+    ACTIVE_MANIFEST_FILE, WORKSPACE_BINDING_FILE,
 };
 use serde_json::json;
 
@@ -138,6 +138,119 @@ fn build_workspace_base_writes_manifest_with_canonical_atomic_path(
         )
     })?;
     assert!(!stale_tmp, "atomic manifest writer left a temporary file");
+    Ok(())
+}
+
+#[test]
+fn shared_workspace_base_reuses_intact_content_addressed_entry(
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let fixture = Fixture::new("shared_workspace_base_cache_hit");
+    let cache = fixture.root.join("cache");
+    std::fs::create_dir_all(fixture.workspace.join("nested"))?;
+    std::fs::write(fixture.workspace.join("tracked.txt"), "base\n")?;
+    std::fs::write(fixture.workspace.join("nested/other.txt"), "other\n")?;
+
+    let built = build_shared_workspace_base(&cache, &fixture.workspace)?;
+    let reused = build_shared_workspace_base(&cache, &fixture.workspace)?;
+
+    assert!(built.built);
+    assert!(!reused.built);
+    assert_eq!(reused.bytes, 0);
+    assert_eq!(reused.root_hash, built.root_hash);
+    assert_eq!(reused.cache_entry_root, built.cache_entry_root);
+    assert_eq!(reused.base_mount_source, built.base_mount_source);
+    assert!(reused.base_mount_source.join("B000001-base").is_dir());
+    assert!(
+        std::fs::read_dir(&cache)?
+            .filter_map(Result::ok)
+            .all(|entry| !entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".building-")),
+        "shared base lookup left a temporary build tree"
+    );
+    Ok(())
+}
+
+#[test]
+fn shared_workspace_base_rejects_deep_cached_file_modification_without_repair(
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let fixture = Fixture::new("shared_workspace_base_cache_modified");
+    let cache = fixture.root.join("cache");
+    std::fs::create_dir_all(fixture.workspace.join("deep/nested"))?;
+    std::fs::write(fixture.workspace.join("deep/nested/tracked.txt"), "base\n")?;
+    let built = build_shared_workspace_base(&cache, &fixture.workspace)?;
+    let cached_file = built
+        .base_mount_source
+        .join("B000001-base/deep/nested/tracked.txt");
+    std::fs::write(&cached_file, "corrupt\n")?;
+
+    let error = build_shared_workspace_base(&cache, &fixture.workspace)
+        .expect_err("modified cached content must fail closed");
+
+    assert!(
+        error
+            .to_string()
+            .contains("shared base cache entry root hash mismatch"),
+        "unexpected error: {error}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(cached_file)?,
+        "corrupt\n",
+        "cache integrity failure must not repair a potentially mounted entry"
+    );
+    Ok(())
+}
+
+#[test]
+fn shared_workspace_base_rejects_deep_cached_file_removal_without_repair(
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let fixture = Fixture::new("shared_workspace_base_cache_missing");
+    let cache = fixture.root.join("cache");
+    std::fs::create_dir_all(fixture.workspace.join("deep/nested"))?;
+    std::fs::write(fixture.workspace.join("deep/nested/tracked.txt"), "base\n")?;
+    let built = build_shared_workspace_base(&cache, &fixture.workspace)?;
+    let cached_file = built
+        .base_mount_source
+        .join("B000001-base/deep/nested/tracked.txt");
+    std::fs::remove_file(&cached_file)?;
+
+    let error = build_shared_workspace_base(&cache, &fixture.workspace)
+        .expect_err("missing cached content must fail closed");
+
+    assert!(
+        error
+            .to_string()
+            .contains("shared base cache entry root hash mismatch"),
+        "unexpected error: {error}"
+    );
+    assert!(
+        !cached_file.exists(),
+        "cache integrity failure must not repair a potentially mounted entry"
+    );
+    assert!(built.cache_entry_root.is_dir());
+    Ok(())
+}
+
+#[test]
+fn shared_workspace_base_cache_lookup_observes_content_changes(
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let fixture = Fixture::new("shared_workspace_base_cache_change");
+    let cache = fixture.root.join("cache");
+    std::fs::create_dir_all(&fixture.workspace)?;
+    std::fs::write(fixture.workspace.join("tracked.txt"), "before\n")?;
+    let before = build_shared_workspace_base(&cache, &fixture.workspace)?;
+
+    std::fs::write(fixture.workspace.join("tracked.txt"), "after\n")?;
+    let after = build_shared_workspace_base(&cache, &fixture.workspace)?;
+
+    assert!(after.built);
+    assert_ne!(after.root_hash, before.root_hash);
+    assert_ne!(after.cache_entry_root, before.cache_entry_root);
+    assert_eq!(
+        std::fs::read_to_string(after.base_mount_source.join("B000001-base/tracked.txt"))?,
+        "after\n"
+    );
     Ok(())
 }
 

--- a/crates/sandbox-runtime/namespace-execution/Cargo.toml
+++ b/crates/sandbox-runtime/namespace-execution/Cargo.toml
@@ -13,11 +13,11 @@ rustix = { workspace = true, features = ["pty", "event", "pipe"] }
 nix = { workspace = true, features = ["signal"] }
 time.workspace = true
 libc.workspace = true
-tokio.workspace = true
 
 [dev-dependencies]
 sandbox-runtime-namespace-process.workspace = true
 serde_json.workspace = true
+tokio.workspace = true
 
 [lints]
 workspace = true

--- a/crates/sandbox-runtime/namespace-execution/src/supervisor.rs
+++ b/crates/sandbox-runtime/namespace-execution/src/supervisor.rs
@@ -4,8 +4,6 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 use sandbox_runtime_namespace_process::runner::protocol::RunResult;
-use tokio::runtime::{Handle as RuntimeHandle, RuntimeFlavor};
-use tokio::sync::Notify;
 
 use crate::error::NamespaceExecutionError;
 use crate::launcher::RunnerChild;
@@ -30,7 +28,6 @@ struct SupervisorQueue {
     shutdown_deadline: Option<Instant>,
     worker_running: bool,
     worker_threads: usize,
-    worker_busy: bool,
     stopped: bool,
     failure: Option<String>,
     shutdown_join_timeouts: usize,
@@ -39,14 +36,12 @@ struct SupervisorQueue {
 struct SupervisorState {
     queue: Mutex<SupervisorQueue>,
     ready: Condvar,
-    async_ready: Notify,
     active: AtomicUsize,
 }
 
 pub(crate) struct CompletionSupervisor {
     state: Arc<SupervisorState>,
     worker: Mutex<Option<JoinHandle<()>>>,
-    async_worker: bool,
 }
 
 impl CompletionSupervisor {
@@ -54,29 +49,8 @@ impl CompletionSupervisor {
         let state = Arc::new(SupervisorState {
             queue: Mutex::new(SupervisorQueue::default()),
             ready: Condvar::new(),
-            async_ready: Notify::new(),
             active: AtomicUsize::new(0),
         });
-
-        if let Ok(runtime) = RuntimeHandle::try_current() {
-            if runtime.runtime_flavor() == RuntimeFlavor::MultiThread {
-                {
-                    let mut queue = state
-                        .queue
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    queue.worker_running = true;
-                }
-                let worker_state = Arc::clone(&state);
-                let worker_guard = AsyncWorkerGuard::new(Arc::clone(&state));
-                runtime.spawn(supervise_async(worker_state, worker_guard));
-                return Self {
-                    state,
-                    worker: Mutex::new(None),
-                    async_worker: true,
-                };
-            }
-        }
 
         let worker_state = Arc::clone(&state);
         let (ready_tx, ready_rx) = mpsc::sync_channel(0);
@@ -114,7 +88,6 @@ impl CompletionSupervisor {
         Self {
             state,
             worker: Mutex::new(worker),
-            async_worker: false,
         }
     }
 
@@ -140,7 +113,6 @@ impl CompletionSupervisor {
             } else {
                 queue.jobs.push(job);
                 self.state.ready.notify_one();
-                self.state.async_ready.notify_one();
             }
             return Err(NamespaceExecutionError::Shutdown);
         }
@@ -151,7 +123,6 @@ impl CompletionSupervisor {
             termination_requested: false,
         });
         self.state.ready.notify_one();
-        self.state.async_ready.notify_one();
         Ok(())
     }
 
@@ -192,15 +163,12 @@ impl CompletionSupervisor {
                 queue.shutdown = true;
                 queue.shutdown_deadline = Some(Instant::now() + SUPERVISOR_SHUTDOWN_TIMEOUT);
             }
-            if !queue.worker_running
-                || (self.async_worker && queue.jobs.is_empty() && !queue.worker_busy)
-            {
+            if !queue.worker_running {
                 queue.worker_running = false;
                 queue.worker_threads = 0;
                 queue.stopped = true;
             }
             self.state.ready.notify_all();
-            self.state.async_ready.notify_waiters();
         }
 
         let worker = self
@@ -218,10 +186,8 @@ impl CompletionSupervisor {
                 queue.failure = Some("completion supervisor panicked".to_owned());
                 queue.worker_running = false;
                 queue.worker_threads = 0;
-                queue.worker_busy = false;
                 queue.stopped = true;
                 self.state.ready.notify_all();
-                self.state.async_ready.notify_waiters();
             }
         } else {
             let mut queue = self
@@ -278,13 +244,10 @@ fn supervise(state: Arc<SupervisorState>) {
             if queue.jobs.is_empty() && queue.shutdown {
                 queue.worker_running = false;
                 queue.worker_threads = 0;
-                queue.worker_busy = false;
                 queue.stopped = true;
                 state.ready.notify_all();
-                state.async_ready.notify_waiters();
                 return;
             }
-            queue.worker_busy = true;
             (std::mem::take(&mut queue.jobs), queue.shutdown_deadline)
         };
 
@@ -303,64 +266,6 @@ fn supervise(state: Arc<SupervisorState>) {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
         }
     }
-}
-
-async fn supervise_async(state: Arc<SupervisorState>, mut guard: AsyncWorkerGuard) {
-    loop {
-        let notified = state.async_ready.notified();
-        let work = {
-            let mut queue = state
-                .queue
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            if queue.stopped || (queue.jobs.is_empty() && queue.shutdown) {
-                queue.worker_running = false;
-                queue.worker_threads = 0;
-                queue.worker_busy = false;
-                queue.stopped = true;
-                state.ready.notify_all();
-                AsyncWork::Stop
-            } else if queue.jobs.is_empty() {
-                AsyncWork::Wait
-            } else {
-                queue.worker_busy = true;
-                AsyncWork::Jobs(std::mem::take(&mut queue.jobs), queue.shutdown_deadline)
-            }
-        };
-
-        let (jobs, shutdown_deadline) = match work {
-            AsyncWork::Stop => {
-                guard.disarm();
-                return;
-            }
-            AsyncWork::Wait => {
-                notified.await;
-                continue;
-            }
-            AsyncWork::Jobs(jobs, shutdown_deadline) => (jobs, shutdown_deadline),
-        };
-        let completed = poll_jobs(&state, jobs, shutdown_deadline);
-        if !completed.is_empty() {
-            let completion_state = Arc::clone(&state);
-            if let Err(error) = tokio::task::spawn_blocking(move || {
-                complete_jobs(&completion_state, completed);
-            })
-            .await
-            {
-                record_worker_failure(&state, format!("completion callback task failed: {error}"));
-            }
-        }
-        let has_pending = finish_batch(&state);
-        if has_pending {
-            tokio::time::sleep(COMPLETION_POLL_INTERVAL).await;
-        }
-    }
-}
-
-enum AsyncWork {
-    Stop,
-    Wait,
-    Jobs(Vec<CompletionJob>, Option<Instant>),
 }
 
 type CompletedJob = (CompletionJob, Result<RunResult, NamespaceExecutionError>);
@@ -412,68 +317,8 @@ fn complete_jobs(state: &SupervisorState, completed: Vec<CompletedJob>) {
     }
 }
 
-fn finish_batch(state: &SupervisorState) -> bool {
-    let mut queue = state
-        .queue
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    queue.worker_busy = false;
-    let has_pending = !queue.jobs.is_empty();
+fn finish_batch(state: &SupervisorState) {
     state.ready.notify_all();
-    state.async_ready.notify_one();
-    has_pending
-}
-
-struct AsyncWorkerGuard {
-    state: Arc<SupervisorState>,
-    armed: bool,
-}
-
-impl AsyncWorkerGuard {
-    fn new(state: Arc<SupervisorState>) -> Self {
-        Self { state, armed: true }
-    }
-
-    fn disarm(&mut self) {
-        self.armed = false;
-    }
-}
-
-impl Drop for AsyncWorkerGuard {
-    fn drop(&mut self) {
-        if !self.armed {
-            return;
-        }
-        let mut queue = self
-            .state
-            .queue
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if !queue.stopped {
-            queue.failure.get_or_insert_with(|| {
-                "async completion supervisor exited unexpectedly".to_owned()
-            });
-            queue.shutdown = true;
-            queue.worker_running = false;
-            queue.worker_threads = 0;
-            queue.worker_busy = false;
-            queue.stopped = true;
-            self.state.ready.notify_all();
-            self.state.async_ready.notify_waiters();
-        }
-    }
-}
-
-fn record_worker_failure(state: &SupervisorState, failure: impl Into<String>) {
-    let mut queue = state
-        .queue
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    queue.failure = Some(failure.into());
-    queue.shutdown = true;
-    queue.shutdown_deadline = Some(Instant::now() + SUPERVISOR_SHUTDOWN_TIMEOUT);
-    state.ready.notify_all();
-    state.async_ready.notify_waiters();
 }
 
 fn record_start_failure(state: &SupervisorState, failure: impl Into<String>) {
@@ -486,9 +331,7 @@ fn record_start_failure(state: &SupervisorState, failure: impl Into<String>) {
     queue.stopped = true;
     queue.worker_running = false;
     queue.worker_threads = 0;
-    queue.worker_busy = false;
     state.ready.notify_all();
-    state.async_ready.notify_waiters();
 }
 
 #[inline(never)]

--- a/crates/sandbox-runtime/namespace-execution/tests/engine.rs
+++ b/crates/sandbox-runtime/namespace-execution/tests/engine.rs
@@ -441,7 +441,6 @@ fn production_engine_initializes_stable_background_workers() {
 
     let workers = engine.background_worker_snapshot();
     assert_eq!(workers.pty_reactor_threads, 1);
-    assert_eq!(workers.active_pty_readers, 0);
     assert_eq!(workers.completion_supervisor_threads, 1);
     assert_eq!(workers.active_completions, 0);
 }

--- a/crates/sandbox-runtime/namespace-execution/tests/supervisor.rs
+++ b/crates/sandbox-runtime/namespace-execution/tests/supervisor.rs
@@ -50,15 +50,30 @@ impl ControlledChild {
 }
 
 #[test]
-fn multithread_runtime_reuses_async_workers_for_completion_polling() {
+fn completion_progress_does_not_depend_on_tokio_blocking_pool_capacity() {
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(2)
+        .max_blocking_threads(1)
         .enable_time()
         .build()
         .expect("build multithread runtime");
     runtime.block_on(async {
+        let (blocking_started_tx, blocking_started_rx) = mpsc::sync_channel(0);
+        let (blocking_release_tx, blocking_release_rx) = mpsc::channel();
+        let blocking_worker = tokio::task::spawn_blocking(move || {
+            blocking_started_tx
+                .send(())
+                .expect("test observes occupied blocking worker");
+            blocking_release_rx
+                .recv()
+                .expect("test releases occupied blocking worker");
+        });
+        blocking_started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("blocking pool worker is occupied");
+
         let supervisor = CompletionSupervisor::new();
-        assert_eq!(supervisor.worker_threads(), 0);
+        assert_eq!(supervisor.worker_threads(), 1);
 
         let terminate_calls = Arc::new(AtomicUsize::new(0));
         let wait_polls = Arc::new(AtomicUsize::new(0));
@@ -73,7 +88,7 @@ fn multithread_runtime_reuses_async_workers_for_completion_polling() {
             )
             .expect("child admitted");
 
-        let result = tokio::time::timeout(Duration::from_secs(1), async {
+        let completion = tokio::time::timeout(Duration::from_secs(1), async {
             loop {
                 match completion_rx.try_recv() {
                     Ok(result) => return result,
@@ -84,18 +99,27 @@ fn multithread_runtime_reuses_async_workers_for_completion_polling() {
                 }
             }
         })
-        .await
-        .expect("completion callback remains responsive")
-        .expect("completed child succeeds");
+        .await;
+
+        blocking_release_tx
+            .send(())
+            .expect("release occupied blocking worker");
+        blocking_worker
+            .await
+            .expect("blocking worker exits after release");
+
+        let result = completion
+            .expect("completion callback remains responsive")
+            .expect("completed child succeeds");
         assert_eq!(result.exit_code, 130);
         assert_eq!(terminate_calls.load(Ordering::SeqCst), 0);
         assert!(wait_polls.load(Ordering::SeqCst) >= 1);
         assert_eq!(supervisor.active(), 0);
-        assert_eq!(supervisor.worker_threads(), 0);
+        assert_eq!(supervisor.worker_threads(), 1);
 
         supervisor
             .shutdown_and_join()
-            .expect("idle async completion worker shuts down cleanly");
+            .expect("dedicated completion worker shuts down cleanly");
         assert_eq!(supervisor.worker_threads(), 0);
     });
 }

--- a/crates/sandbox-runtime/workspace/src/namespace/holder.rs
+++ b/crates/sandbox-runtime/workspace/src/namespace/holder.rs
@@ -38,6 +38,7 @@ const SUPERVISOR_QUEUE_CAPACITY: usize = 64;
 const HOLDER_PROBE_REPLY_TIMEOUT: Duration = Duration::from_millis(250);
 const HOLDER_FINALIZATION_REPLY_TIMEOUT: Duration = Duration::from_millis(1_500);
 const KILL_REAP_TIMEOUT: Duration = Duration::from_secs(1);
+const TERMINATION_POLL_INTERVAL: Duration = Duration::from_millis(5);
 const WAIT_REAP_RETRY_BACKOFF: Duration = Duration::from_millis(50);
 const WAIT_ERROR_LIMIT: u8 = 3;
 #[cfg(target_os = "linux")]
@@ -806,7 +807,7 @@ fn supervisor_loop(
                 Err(_) => break,
             }
         } else {
-            match rx.recv_timeout(poll_interval) {
+            match rx.recv_timeout(supervisor_poll_interval(&records, poll_interval)) {
                 Ok(command) => handle_supervisor_command(command, &mut records, &log),
                 Err(RecvTimeoutError::Timeout) => {}
                 Err(RecvTimeoutError::Disconnected) => {
@@ -816,6 +817,17 @@ fn supervisor_loop(
             }
         }
         poll_holder_records(&mut records, &log);
+    }
+}
+
+fn supervisor_poll_interval(
+    records: &HashMap<RegistrationKey, HolderRecord>,
+    idle_interval: Duration,
+) -> Duration {
+    if records.values().any(|record| record.termination.is_some()) {
+        idle_interval.min(TERMINATION_POLL_INTERVAL)
+    } else {
+        idle_interval
     }
 }
 

--- a/crates/sandbox-runtime/workspace/tests/internal/holder.rs
+++ b/crates/sandbox-runtime/workspace/tests/internal/holder.rs
@@ -916,6 +916,35 @@ fn long_destroy_grace_does_not_delay_peer_exit_detection() {
 }
 
 #[test]
+fn active_termination_accelerates_polling_without_changing_idle_cadence() {
+    let idle_interval = Duration::from_millis(200);
+    let supervisor = HolderSupervisor::new(idle_interval, 8);
+    let process = Arc::new(FakeProcessState::default());
+    *process
+        .delayed_exit_after_signal
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(Duration::from_millis(10));
+    let registration = registered(&supervisor, "workspace-termination-aware-poll", &process);
+    wait_for_count(&process.try_wait_calls, 1, Duration::from_secs(1));
+    let idle_poll_count = process.try_wait_calls.load(Ordering::SeqCst);
+
+    std::thread::sleep(Duration::from_millis(50));
+    assert_eq!(
+        process.try_wait_calls.load(Ordering::SeqCst),
+        idle_poll_count
+    );
+
+    let started = Instant::now();
+    supervisor
+        .terminate(&registration, Duration::from_secs(1))
+        .expect("termination observes the delayed exit");
+
+    assert!(started.elapsed() < Duration::from_millis(150));
+    assert_eq!(process.signals.load(Ordering::SeqCst), 1);
+    assert_eq!(process.reaps.load(Ordering::SeqCst), 1);
+}
+
+#[test]
 fn pid_parent_start_time_and_executable_mismatches_refuse_signal() {
     let mutations: [fn(&mut HolderIdentity); 4] = [
         |identity| identity.pid += 1,

--- a/docs/windows-setup.md
+++ b/docs/windows-setup.md
@@ -84,7 +84,7 @@ Set-Content target\windows-gateway.token $env:SANDBOX_GATEWAY_AUTH_TOKEN
 target\debug\sandbox-gateway.exe serve `
   --backend docker `
   --config-yaml config\windows-amd64.yml `
-  --gateway-socket 127.0.0.1:7878 `
+  --gateway-endpoint npipe://./pipe/ephemeral-sandbox-gateway `
   --auth-token $env:SANDBOX_GATEWAY_AUTH_TOKEN `
   --pid-file target\windows-gateway.pid
 ```
@@ -108,12 +108,12 @@ if (-not $smoke) {
 }
 
 target\debug\sandbox-manager-cli.exe `
-  --gateway-socket 127.0.0.1:7878 `
+  --gateway-endpoint npipe://./pipe/ephemeral-sandbox-gateway `
   --gateway-auth-token $env:SANDBOX_GATEWAY_AUTH_TOKEN `
   list_docker_images
 
 $created = target\debug\sandbox-manager-cli.exe `
-  --gateway-socket 127.0.0.1:7878 `
+  --gateway-endpoint npipe://./pipe/ephemeral-sandbox-gateway `
   --gateway-auth-token $env:SANDBOX_GATEWAY_AUTH_TOKEN `
   create_sandbox `
   --image alpine:3.20 `
@@ -122,13 +122,13 @@ $created = target\debug\sandbox-manager-cli.exe `
 $sandboxId = ($created | ConvertFrom-Json).id
 
 target\debug\sandbox-runtime-cli.exe `
-  --gateway-socket 127.0.0.1:7878 `
+  --gateway-endpoint npipe://./pipe/ephemeral-sandbox-gateway `
   --gateway-auth-token $env:SANDBOX_GATEWAY_AUTH_TOKEN `
   --sandbox-id $sandboxId `
   exec_command "pwd && cat README.txt && ls src"
 
 target\debug\sandbox-observability-cli.exe `
-  --gateway-socket 127.0.0.1:7878 `
+  --gateway-endpoint npipe://./pipe/ephemeral-sandbox-gateway `
   --gateway-auth-token $env:SANDBOX_GATEWAY_AUTH_TOKEN `
   snapshot --sandbox-id $sandboxId
 ```
@@ -139,6 +139,9 @@ workspace`, and `main.txt`.
 ## Run The Web Console
 
 The browser UI lives in the separate console repository.
+The console currently uses TCP, so stop the named-pipe gateway and restart the
+packaged launcher with
+`-GatewaySocket tcp://127.0.0.1:7878` before starting the console.
 
 ```powershell
 cd ..


### PR DESCRIPTION
## Summary

- reduce one-shot CLI and sandbox startup overhead across the runtime, layer stack, observability, and gateway paths
- use local IPC for gateway CLI transport while preserving TCP endpoint compatibility
- harden request identity, workspace writes, namespace completion, resource sampling, and daemon archive behavior encountered during EXP1
- merge the latest documentation-only `origin/main` update without rewriting the frozen experiment commits

## Validation

- focused changed-crate and CLI transport tests passed during the frozen campaign
- real named-pipe request/response and concurrency-5 qualification passed
- final EXP1 v1.1 campaign completed 1,900 reportable measured batches and 5,610 requests with zero classified failures

## Notes

- this PR is intentionally draft-only; the experiment code must remain off `main` for now
- annotated freeze tag `paper-v1.1-freeze` points to product commit `5c48dae10847fb9e46ba2bea7675bcf2f5a6f4c8`
