### PR TITLE
Add Windows named-pipe gateway compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ The UI lives in the separate
 [Ephemeral Sandbox Console](https://github.com/Ephemeral-AI-Lab/ephemeral-sandbox-console)
 repository. Start the gateway above, then point the console at:
 
-- socket: `127.0.0.1:7878`
+- Windows CLI/MCP endpoint: `npipe://./pipe/ephemeral-sandbox-gateway`
+- console socket after explicitly starting the gateway on TCP: `127.0.0.1:7878`
 - Linux/macOS token: `$HOME/.ephemeral-sandbox/gateway.token`
 - Windows token: `$HOME\.ephemeral-sandbox\gateway.token`
 

--- a/bin/package-windows-amd64-release.ps1
+++ b/bin/package-windows-amd64-release.ps1
@@ -104,7 +104,7 @@ Use the gateway from another PowerShell window:
 ```powershell
 $env:SANDBOX_GATEWAY_AUTH_TOKEN = Get-Content "$HOME\.ephemeral-sandbox\gateway.token"
 $env:SANDBOX_IMAGE = "alpine:3.20"
-.\bin\sandbox-manager-cli.exe --gateway-socket 127.0.0.1:7878 --gateway-auth-token $env:SANDBOX_GATEWAY_AUTH_TOKEN list_docker_images
+.\bin\sandbox-manager-cli.exe --gateway-endpoint npipe://./pipe/ephemeral-sandbox-gateway --gateway-auth-token $env:SANDBOX_GATEWAY_AUTH_TOKEN list_docker_images
 ```
 '@ | Set-Content -LiteralPath (Join-Path $stageDir "INSTALL.md") -Encoding UTF8
 

--- a/bin/start-sandbox-windows-docker-gateway.ps1
+++ b/bin/start-sandbox-windows-docker-gateway.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string]$GatewaySocket = $(if ($env:SANDBOX_GATEWAY_SOCKET) { $env:SANDBOX_GATEWAY_SOCKET } else { "127.0.0.1:7878" }),
+    [string]$GatewaySocket = $(if ($env:SANDBOX_GATEWAY_SOCKET) { $env:SANDBOX_GATEWAY_SOCKET } else { "npipe://./pipe/ephemeral-sandbox-gateway" }),
     [string]$ConfigYaml = $(if ($env:SANDBOX_GATEWAY_CONFIG_YAML) { $env:SANDBOX_GATEWAY_CONFIG_YAML } else { "" }),
     [string]$PidFile = $(if ($env:SANDBOX_GATEWAY_PID_FILE) { $env:SANDBOX_GATEWAY_PID_FILE } else { Join-Path $env:TEMP "eos-gateway-windows.pid" }),
     [string]$LogPath = $(if ($env:SANDBOX_GATEWAY_LOG) { $env:SANDBOX_GATEWAY_LOG } else { Join-Path $env:TEMP "eos-gateway-windows.log" })
@@ -100,7 +100,7 @@ $gatewayArgs = @(
     "serve",
     "--backend", "docker",
     "--config-yaml", $ConfigYaml,
-    "--gateway-socket", $GatewaySocket,
+    "--gateway-endpoint", $GatewaySocket,
     "--auth-token", $authToken,
     "--pid-file", $PidFile
 )
@@ -130,7 +130,7 @@ for ($i = 0; $i -lt 30; $i++) {
 
 Write-Host "sandbox-gateway starting in background via pid $($process.Id)"
 Write-Host "pid file: $PidFile"
-Write-Host "address: $GatewaySocket"
+Write-Host "endpoint: $GatewaySocket"
 Write-Host "auth token file: $tokenPath"
 Write-Host "log: $LogPath"
 Write-Host "error log: $errorLogPath"

--- a/crates/sandbox-cli/src/manager.rs
+++ b/crates/sandbox-cli/src/manager.rs
@@ -28,7 +28,12 @@ const CREATE_SANDBOX_OP: &str = "create_sandbox";
 #[derive(Debug, Parser)]
 #[command(name = "sandbox-manager-cli", disable_help_subcommand = true)]
 struct Cli {
-    #[arg(long = "gateway-socket", value_name = "HOST:PORT", global = true)]
+    #[arg(
+        long = "gateway-endpoint",
+        visible_alias = "gateway-socket",
+        value_name = "URI",
+        global = true
+    )]
     gateway_socket_path: Option<PathBuf>,
 
     #[arg(long = "gateway-auth-token", value_name = "TOKEN", global = true)]
@@ -168,8 +173,8 @@ where
     WErr: Write,
 {
     let config = discover_config(overrides, stderr).ok()?;
-    Some(GatewayClient::new(
-        config.gateway_socket_path.to_string_lossy().into_owned(),
-        config.gateway_auth_token.clone(),
+    Some(GatewayClient::from_endpoint(
+        config.gateway_endpoint,
+        config.gateway_auth_token,
     ))
 }

--- a/crates/sandbox-cli/src/observability.rs
+++ b/crates/sandbox-cli/src/observability.rs
@@ -24,7 +24,12 @@ const HELP_OP: &str = "help";
 #[derive(Debug, Parser)]
 #[command(name = "sandbox-observability-cli", disable_help_subcommand = true)]
 struct Cli {
-    #[arg(long = "gateway-socket", value_name = "HOST:PORT", global = true)]
+    #[arg(
+        long = "gateway-endpoint",
+        visible_alias = "gateway-socket",
+        value_name = "URI",
+        global = true
+    )]
     gateway_socket_path: Option<PathBuf>,
 
     #[arg(long = "gateway-auth-token", value_name = "TOKEN", global = true)]
@@ -112,8 +117,8 @@ where
     WErr: Write,
 {
     let config = discover_config(overrides, stderr).ok()?;
-    Some(GatewayClient::new(
-        config.gateway_socket_path.to_string_lossy().into_owned(),
-        config.gateway_auth_token.clone(),
+    Some(GatewayClient::from_endpoint(
+        config.gateway_endpoint,
+        config.gateway_auth_token,
     ))
 }

--- a/crates/sandbox-cli/src/runtime.rs
+++ b/crates/sandbox-cli/src/runtime.rs
@@ -31,7 +31,12 @@ const REQUEST_ID_ERROR: &str =
 #[derive(Debug, Parser)]
 #[command(name = "sandbox-runtime-cli", disable_help_subcommand = true)]
 struct Cli {
-    #[arg(long = "gateway-socket", value_name = "HOST:PORT", global = true)]
+    #[arg(
+        long = "gateway-endpoint",
+        visible_alias = "gateway-socket",
+        value_name = "URI",
+        global = true
+    )]
     gateway_socket_path: Option<PathBuf>,
 
     #[arg(long = "gateway-auth-token", value_name = "TOKEN", global = true)]
@@ -168,8 +173,8 @@ where
     WErr: Write,
 {
     let config = discover_config(overrides, stderr).ok()?;
-    Some(GatewayClient::new(
-        config.gateway_socket_path.to_string_lossy().into_owned(),
-        config.gateway_auth_token.clone(),
+    Some(GatewayClient::from_endpoint(
+        config.gateway_endpoint,
+        config.gateway_auth_token,
     ))
 }

--- a/crates/sandbox-cli/tests/manager.rs
+++ b/crates/sandbox-cli/tests/manager.rs
@@ -185,6 +185,26 @@ async fn omitted_create_count_uses_catalog_default() {
 }
 
 #[tokio::test]
+async fn explicit_gateway_endpoint_accepts_a_typed_tcp_uri() {
+    let response = json!({"sandboxes": []});
+    let (addr, received) = fake_gateway(response.clone()).await;
+    let endpoint = format!("tcp://{addr}");
+    let (code, stdout, stderr) = run(&[
+        "sandbox-manager-cli",
+        "--gateway-endpoint",
+        &endpoint,
+        "list_sandboxes",
+    ])
+    .await;
+
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+    assert_eq!(parse_json_line(&stdout), response);
+    let request = received.await.expect("fake gateway task");
+    assert_eq!(request["op"], "list_sandboxes");
+}
+
+#[tokio::test]
 async fn progress_streams_to_stderr_and_keeps_final_json_on_stdout() {
     let response = json!({"sandboxes": []});
     let raw_response = format!("cli_log(\"manager fixture progress\")\n{response}\n").into_bytes();

--- a/crates/sandbox-config/src/configs/gateway.rs
+++ b/crates/sandbox-config/src/configs/gateway.rs
@@ -1,19 +1,89 @@
 //! Typed schema for the optional `gateway` section of the sandbox config,
 //! doubling as the gateway server's runtime config.
 
+use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use serde::Deserialize;
+use thiserror::Error;
 
-use crate::configs::validate::{
-    require_non_empty, require_socket_addr, require_usize_at_least, ConfigFieldError,
-};
+use crate::configs::validate::{require_non_empty, require_usize_at_least, ConfigFieldError};
 
+#[cfg(windows)]
+pub const DEFAULT_GATEWAY_SOCKET: &str = "npipe://./pipe/ephemeral-sandbox-gateway";
+#[cfg(not(windows))]
 pub const DEFAULT_GATEWAY_SOCKET: &str = "127.0.0.1:7878";
 pub const DEFAULT_GATEWAY_PID: &str = "/tmp/eos-gateway.pid";
 pub const DEFAULT_MAX_CONCURRENT_CONNECTIONS: usize = 256;
 pub const SANDBOX_GATEWAY_SOCKET_ENV: &str = "SANDBOX_GATEWAY_SOCKET";
 pub const SANDBOX_GATEWAY_AUTH_TOKEN_ENV: &str = "SANDBOX_GATEWAY_AUTH_TOKEN";
+
+/// A validated gateway transport endpoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GatewayEndpoint {
+    Tcp(SocketAddr),
+    WindowsNamedPipe(String),
+    UnixSocket(PathBuf),
+}
+
+impl FromStr for GatewayEndpoint {
+    type Err = GatewayEndpointParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.trim() != value {
+            return Err(GatewayEndpointParseError::new(
+                "surrounding whitespace is not allowed",
+            ));
+        }
+        if let Some(address) = value.strip_prefix("tcp://") {
+            return parse_tcp(address);
+        }
+        if let Some(name) = value.strip_prefix("npipe://./pipe/") {
+            return parse_named_pipe(name);
+        }
+        if let Some(path) = value.strip_prefix("unix://") {
+            return parse_unix_socket(path);
+        }
+        if value.contains("://") {
+            return Err(GatewayEndpointParseError::new(
+                "supported schemes are tcp, npipe, and unix",
+            ));
+        }
+        parse_tcp(value)
+    }
+}
+
+impl std::fmt::Display for GatewayEndpoint {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Tcp(address) => write!(formatter, "tcp://{address}"),
+            Self::WindowsNamedPipe(path) => {
+                let name = path
+                    .strip_prefix(r"\\.\pipe\")
+                    .unwrap_or(path)
+                    .replace('\\', "/");
+                write!(formatter, "npipe://./pipe/{name}")
+            }
+            Self::UnixSocket(path) => write!(formatter, "unix://{}", path.display()),
+        }
+    }
+}
+
+/// An invalid gateway endpoint string.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("invalid gateway endpoint: {reason}")]
+pub struct GatewayEndpointParseError {
+    reason: String,
+}
+
+impl GatewayEndpointParseError {
+    fn new(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+        }
+    }
+}
 
 /// Gateway server config. The YAML `gateway` section feeds `bind_addr`,
 /// `pid_path`, and `max_concurrent_connections`; the auth token is runtime
@@ -60,7 +130,8 @@ impl GatewayConfig {
     /// # Errors
     /// Returns an error when a field violates gateway policy.
     pub fn validate(&self) -> Result<(), ConfigFieldError> {
-        require_socket_addr(&self.bind_addr, "gateway.bind_addr")?;
+        self.endpoint()
+            .map_err(|error| ConfigFieldError::new("gateway.bind_addr", error.to_string()))?;
         require_non_empty(&self.pid_path.to_string_lossy(), "gateway.pid_path")?;
         require_usize_at_least(
             self.max_concurrent_connections,
@@ -68,4 +139,79 @@ impl GatewayConfig {
             "gateway.max_concurrent_connections",
         )
     }
+
+    /// Parse the configured bind value into its transport-specific endpoint.
+    ///
+    /// # Errors
+    /// Returns an error when the endpoint syntax or transport value is unsafe.
+    pub fn endpoint(&self) -> Result<GatewayEndpoint, GatewayEndpointParseError> {
+        self.bind_addr.parse()
+    }
+}
+
+fn parse_tcp(value: &str) -> Result<GatewayEndpoint, GatewayEndpointParseError> {
+    let address = value.parse::<SocketAddr>().map_err(|_| {
+        GatewayEndpointParseError::new(format!("`{value}` must be an IP host:port address"))
+    })?;
+    if address.port() == 0 {
+        return Err(GatewayEndpointParseError::new(
+            "TCP port must be greater than zero",
+        ));
+    }
+    Ok(GatewayEndpoint::Tcp(address))
+}
+
+fn parse_named_pipe(value: &str) -> Result<GatewayEndpoint, GatewayEndpointParseError> {
+    validate_endpoint_segments(value, "named-pipe name")?;
+    if value.chars().any(|character| {
+        !character.is_ascii_alphanumeric() && !matches!(character, '/' | '-' | '_' | '.')
+    }) {
+        return Err(GatewayEndpointParseError::new(
+            "named-pipe name may contain only ASCII letters, digits, `/`, `-`, `_`, and `.`",
+        ));
+    }
+    let path = format!(r"\\.\pipe\{}", value.replace('/', r"\"));
+    if path.encode_utf16().count() > 256 {
+        return Err(GatewayEndpointParseError::new(
+            "named-pipe path exceeds the Windows 256-character limit",
+        ));
+    }
+    Ok(GatewayEndpoint::WindowsNamedPipe(path))
+}
+
+fn parse_unix_socket(value: &str) -> Result<GatewayEndpoint, GatewayEndpointParseError> {
+    if !value.starts_with('/') {
+        return Err(GatewayEndpointParseError::new(
+            "Unix-socket path must be absolute",
+        ));
+    }
+    let relative = value.trim_start_matches('/');
+    validate_endpoint_segments(relative, "Unix-socket path")?;
+    if value.len() > 100 {
+        return Err(GatewayEndpointParseError::new(
+            "Unix-socket path exceeds the portable 100-byte limit",
+        ));
+    }
+    if value.chars().any(char::is_control) || value.contains('\\') {
+        return Err(GatewayEndpointParseError::new(
+            "Unix-socket path contains an unsafe character",
+        ));
+    }
+    Ok(GatewayEndpoint::UnixSocket(PathBuf::from(value)))
+}
+
+fn validate_endpoint_segments(
+    value: &str,
+    description: &str,
+) -> Result<(), GatewayEndpointParseError> {
+    if value.is_empty()
+        || value
+            .split('/')
+            .any(|segment| segment.is_empty() || matches!(segment, "." | ".."))
+    {
+        return Err(GatewayEndpointParseError::new(format!(
+            "{description} must contain non-empty path segments without `.` or `..`"
+        )));
+    }
+    Ok(())
 }

--- a/crates/sandbox-config/src/configs/gateway.rs
+++ b/crates/sandbox-config/src/configs/gateway.rs
@@ -185,7 +185,9 @@ fn parse_unix_socket(value: &str) -> Result<GatewayEndpoint, GatewayEndpointPars
             "Unix-socket path must be absolute",
         ));
     }
-    let relative = value.trim_start_matches('/');
+    let relative = value
+        .strip_prefix('/')
+        .ok_or_else(|| GatewayEndpointParseError::new("Unix-socket path must be absolute"))?;
     validate_endpoint_segments(relative, "Unix-socket path")?;
     if value.len() > 100 {
         return Err(GatewayEndpointParseError::new(

--- a/crates/sandbox-config/tests/unit/configs/gateway.rs
+++ b/crates/sandbox-config/tests/unit/configs/gateway.rs
@@ -70,6 +70,7 @@ fn gateway_endpoints_reject_unsafe_or_ambiguous_values() {
         "npipe://./pipe/../escape",
         "npipe://./pipe/name\\escape",
         "unix://relative.sock",
+        "unix:////tmp/ambiguous.sock",
         "unix:///tmp/../escape.sock",
         "unix:///tmp//ambiguous.sock",
     ];

--- a/crates/sandbox-config/tests/unit/configs/gateway.rs
+++ b/crates/sandbox-config/tests/unit/configs/gateway.rs
@@ -19,12 +19,76 @@ fn gateway_server_config_constructs_from_defaults() {
 }
 
 #[test]
+fn gateway_endpoints_parse_supported_transports_and_legacy_tcp() {
+    let endpoints = [
+        (
+            "127.0.0.1:7878",
+            GatewayEndpoint::Tcp("127.0.0.1:7878".parse().expect("socket address")),
+        ),
+        (
+            "tcp://[::1]:7878",
+            GatewayEndpoint::Tcp("[::1]:7878".parse().expect("socket address")),
+        ),
+        (
+            "npipe://./pipe/ephemeral-sandbox/user-1",
+            GatewayEndpoint::WindowsNamedPipe(
+                r"\\.\pipe\ephemeral-sandbox\user-1".to_owned(),
+            ),
+        ),
+        (
+            "unix:///tmp/ephemeral-sandbox.sock",
+            GatewayEndpoint::UnixSocket(PathBuf::from("/tmp/ephemeral-sandbox.sock")),
+        ),
+    ];
+
+    for (raw, expected) in endpoints {
+        let parsed = raw
+            .parse::<GatewayEndpoint>()
+            .expect("supported endpoint parses");
+        assert_eq!(parsed, expected);
+        assert_eq!(
+            parsed.to_string(),
+            match raw {
+                "127.0.0.1:7878" => "tcp://127.0.0.1:7878",
+                _ => raw,
+            }
+        );
+    }
+}
+
+#[test]
+fn gateway_endpoints_reject_unsafe_or_ambiguous_values() {
+    let invalid = [
+        "",
+        " 127.0.0.1:7878",
+        "127.0.0.1:7878 ",
+        "http://127.0.0.1:7878",
+        "tcp://localhost:7878",
+        "tcp://127.0.0.1:0",
+        "npipe://server/pipe/name",
+        "npipe://./pipe/",
+        "npipe://./pipe/../escape",
+        "npipe://./pipe/name\\escape",
+        "unix://relative.sock",
+        "unix:///tmp/../escape.sock",
+        "unix:///tmp//ambiguous.sock",
+    ];
+
+    for value in invalid {
+        let error = value
+            .parse::<GatewayEndpoint>()
+            .expect_err("unsafe endpoint must fail");
+        assert!(error.to_string().contains("invalid gateway endpoint"));
+    }
+}
+
+#[test]
 fn config_gateway_defaults_preserve_shipped_policy() {
     // prd.yml carries no gateway section, so the section must load to
     // today's exact constants.
     let config = GatewayConfig::default();
     config.validate().expect("default gateway config is valid");
-    assert_eq!(config.bind_addr, "127.0.0.1:7878");
+    assert_eq!(config.bind_addr, DEFAULT_GATEWAY_SOCKET);
     assert_eq!(config.pid_path, PathBuf::from("/tmp/eos-gateway.pid"));
     assert_eq!(config.max_concurrent_connections, 256);
     assert!(config.auth_token.is_none());
@@ -84,6 +148,20 @@ fn config_validation_rejects_gateway_edge_values() {
         (
             GatewayConfig {
                 bind_addr: "not-an-address".to_owned(),
+                ..GatewayConfig::default()
+            },
+            "gateway.bind_addr",
+        ),
+        (
+            GatewayConfig {
+                bind_addr: "npipe://./pipe/../escape".to_owned(),
+                ..GatewayConfig::default()
+            },
+            "gateway.bind_addr",
+        ),
+        (
+            GatewayConfig {
+                bind_addr: "unix://relative.sock".to_owned(),
                 ..GatewayConfig::default()
             },
             "gateway.bind_addr",

--- a/crates/sandbox-gateway/src/gateway/config.rs
+++ b/crates/sandbox-gateway/src/gateway/config.rs
@@ -1,8 +1,9 @@
 use std::path::PathBuf;
 
 pub use sandbox_config::configs::gateway::{
-    GatewayConfig, DEFAULT_GATEWAY_PID, DEFAULT_GATEWAY_SOCKET, DEFAULT_MAX_CONCURRENT_CONNECTIONS,
-    SANDBOX_GATEWAY_AUTH_TOKEN_ENV, SANDBOX_GATEWAY_SOCKET_ENV,
+    GatewayConfig, GatewayEndpoint, GatewayEndpointParseError, DEFAULT_GATEWAY_PID,
+    DEFAULT_GATEWAY_SOCKET, DEFAULT_MAX_CONCURRENT_CONNECTIONS, SANDBOX_GATEWAY_AUTH_TOKEN_ENV,
+    SANDBOX_GATEWAY_SOCKET_ENV,
 };
 
 /// CLI-flag overrides for the gateway server; `None` means the flag was not

--- a/crates/sandbox-gateway/src/gateway/lifecycle.rs
+++ b/crates/sandbox-gateway/src/gateway/lifecycle.rs
@@ -1,20 +1,23 @@
 use std::sync::Arc;
 
 use tokio::io::{AsyncWrite, AsyncWriteExt};
-use tokio::net::TcpListener;
 use tokio::sync::Semaphore;
 
+use super::listener::GatewayListener;
 use super::{error, GatewayError, SandboxGatewayServer};
 
 impl SandboxGatewayServer {
     pub async fn serve(self) -> Result<(), GatewayError> {
         let server = Arc::new(self);
         prepare_paths(&server).await?;
-        let listener = TcpListener::bind(server.config.bind_addr.as_str()).await?;
+        let endpoint = server.config.endpoint().map_err(|error| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, error.to_string())
+        })?;
+        let mut listener =
+            GatewayListener::bind(endpoint, server.config.max_concurrent_connections).await?;
         tokio::fs::write(&server.config.pid_path, std::process::id().to_string()).await?;
-
         let permits = Arc::new(Semaphore::new(server.config.max_concurrent_connections));
-        let result = accept_until_shutdown(Arc::clone(&server), listener, permits).await;
+        let result = accept_until_shutdown(Arc::clone(&server), &mut listener, permits).await;
         cleanup_paths(&server).await;
         result
     }
@@ -29,14 +32,14 @@ async fn prepare_paths(server: &SandboxGatewayServer) -> Result<(), GatewayError
 
 async fn accept_until_shutdown(
     server: Arc<SandboxGatewayServer>,
-    listener: TcpListener,
+    listener: &mut GatewayListener,
     permits: Arc<Semaphore>,
 ) -> Result<(), GatewayError> {
     loop {
         tokio::select! {
             () = server.shutdown.cancelled() => return Ok(()),
             accepted = listener.accept() => {
-                let (stream, _) = accepted?;
+                let stream = accepted?;
                 let Ok(permit) = Arc::clone(&permits).try_acquire_owned() else {
                     tokio::spawn(reject_overloaded_connection(
                         stream,

--- a/crates/sandbox-gateway/src/gateway/listener.rs
+++ b/crates/sandbox-gateway/src/gateway/listener.rs
@@ -1,0 +1,243 @@
+use std::io;
+
+use sandbox_config::configs::gateway::GatewayEndpoint;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::TcpListener;
+
+pub(crate) trait GatewayIo: AsyncRead + AsyncWrite + Unpin + Send {}
+
+impl<T> GatewayIo for T where T: AsyncRead + AsyncWrite + Unpin + Send {}
+
+pub(crate) type GatewayStream = Box<dyn GatewayIo>;
+
+pub(crate) enum GatewayListener {
+    Tcp(TcpListener),
+    #[cfg(windows)]
+    WindowsNamedPipe(windows::WindowsNamedPipeListener),
+    #[cfg(unix)]
+    UnixSocket(unix::UnixSocketListener),
+}
+
+impl GatewayListener {
+    pub(crate) async fn bind(
+        endpoint: GatewayEndpoint,
+        max_connections: usize,
+    ) -> io::Result<Self> {
+        match endpoint {
+            GatewayEndpoint::Tcp(address) => Ok(Self::Tcp(TcpListener::bind(address).await?)),
+            GatewayEndpoint::WindowsNamedPipe(path) => {
+                #[cfg(windows)]
+                {
+                    Ok(Self::WindowsNamedPipe(
+                        windows::WindowsNamedPipeListener::bind(path, max_connections)?,
+                    ))
+                }
+                #[cfg(not(windows))]
+                {
+                    let _ = (path, max_connections);
+                    Err(unsupported_transport("npipe"))
+                }
+            }
+            GatewayEndpoint::UnixSocket(path) => {
+                #[cfg(unix)]
+                {
+                    Ok(Self::UnixSocket(unix::UnixSocketListener::bind(path)?))
+                }
+                #[cfg(not(unix))]
+                {
+                    let _ = (path, max_connections);
+                    Err(unsupported_transport("unix"))
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn accept(&mut self) -> io::Result<GatewayStream> {
+        match self {
+            Self::Tcp(listener) => {
+                let (stream, _) = listener.accept().await?;
+                Ok(Box::new(stream))
+            }
+            #[cfg(windows)]
+            Self::WindowsNamedPipe(listener) => listener.accept().await,
+            #[cfg(unix)]
+            Self::UnixSocket(listener) => listener.accept().await,
+        }
+    }
+}
+
+fn unsupported_transport(scheme: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::Unsupported,
+        format!("{scheme} gateway endpoints are unsupported on this platform"),
+    )
+}
+
+#[cfg(windows)]
+mod windows {
+    use std::io;
+    use std::time::Duration;
+
+    use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
+    use tokio::task::JoinSet;
+
+    use super::GatewayStream;
+
+    const MIN_PENDING_INSTANCES: usize = 8;
+    const MAX_PENDING_INSTANCES: usize = 32;
+    const ERROR_PIPE_BUSY: i32 = 231;
+
+    pub(crate) struct WindowsNamedPipeListener {
+        path: String,
+        pending_target: usize,
+        pending: JoinSet<io::Result<NamedPipeServer>>,
+    }
+
+    impl WindowsNamedPipeListener {
+        pub(super) fn bind(path: String, max_connections: usize) -> io::Result<Self> {
+            let pending_target = max_connections
+                .saturating_add(1)
+                .clamp(MIN_PENDING_INSTANCES, MAX_PENDING_INSTANCES);
+            let mut listener = Self {
+                path,
+                pending_target,
+                pending: JoinSet::new(),
+            };
+            let first = listener.create_instance(true)?;
+            listener.spawn_pending(first);
+            listener.replenish()?;
+            Ok(listener)
+        }
+
+        pub(super) async fn accept(&mut self) -> io::Result<GatewayStream> {
+            loop {
+                match self.replenish() {
+                    Ok(()) => {}
+                    Err(error)
+                        if error.raw_os_error() == Some(ERROR_PIPE_BUSY)
+                            && !self.pending.is_empty() => {}
+                    Err(error) if error.raw_os_error() == Some(ERROR_PIPE_BUSY) => {
+                        tokio::time::sleep(Duration::from_millis(1)).await;
+                        continue;
+                    }
+                    Err(error) => return Err(error),
+                }
+                let joined = self.pending.join_next().await.ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::BrokenPipe, "named-pipe listener stopped")
+                })?;
+                let stream = joined.map_err(|error| {
+                    io::Error::other(format!("named-pipe accept task failed: {error}"))
+                })??;
+                return Ok(Box::new(stream));
+            }
+        }
+
+        fn replenish(&mut self) -> io::Result<()> {
+            while self.pending.len() < self.pending_target {
+                let instance = self.create_instance(false)?;
+                self.spawn_pending(instance);
+            }
+            Ok(())
+        }
+
+        fn create_instance(&mut self, first: bool) -> io::Result<NamedPipeServer> {
+            let mut options = ServerOptions::new();
+            options
+                .first_pipe_instance(first)
+                .reject_remote_clients(true);
+            options.create(&self.path)
+        }
+
+        fn spawn_pending(&mut self, instance: NamedPipeServer) {
+            self.pending.spawn(async move {
+                instance.connect().await?;
+                Ok(instance)
+            });
+        }
+    }
+}
+
+#[cfg(unix)]
+mod unix {
+    use std::fs;
+    use std::io;
+    use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
+    use std::path::PathBuf;
+
+    use tokio::net::UnixListener;
+
+    use super::GatewayStream;
+
+    pub(crate) struct UnixSocketListener {
+        listener: UnixListener,
+        path: PathBuf,
+        identity: SocketIdentity,
+    }
+
+    impl UnixSocketListener {
+        pub(super) fn bind(path: PathBuf) -> io::Result<Self> {
+            match fs::symlink_metadata(&path) {
+                Ok(_) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::AlreadyExists,
+                        format!("gateway Unix socket already exists: {}", path.display()),
+                    ));
+                }
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+            let listener = UnixListener::bind(&path)?;
+            if let Err(error) = fs::set_permissions(&path, fs::Permissions::from_mode(0o600)) {
+                let _ = fs::remove_file(&path);
+                return Err(error);
+            }
+            let metadata = fs::symlink_metadata(&path)?;
+            let identity = SocketIdentity::from_metadata(&metadata)?;
+            Ok(Self {
+                listener,
+                path,
+                identity,
+            })
+        }
+
+        pub(super) async fn accept(&self) -> io::Result<GatewayStream> {
+            let (stream, _) = self.listener.accept().await?;
+            Ok(Box::new(stream))
+        }
+    }
+
+    impl Drop for UnixSocketListener {
+        fn drop(&mut self) {
+            let Ok(metadata) = fs::symlink_metadata(&self.path) else {
+                return;
+            };
+            let Ok(identity) = SocketIdentity::from_metadata(&metadata) else {
+                return;
+            };
+            if identity == self.identity {
+                let _ = fs::remove_file(&self.path);
+            }
+        }
+    }
+
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    struct SocketIdentity {
+        device: u64,
+        inode: u64,
+    }
+
+    impl SocketIdentity {
+        fn from_metadata(metadata: &fs::Metadata) -> io::Result<Self> {
+            if !metadata.file_type().is_socket() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "gateway endpoint is not a Unix socket",
+                ));
+            }
+            Ok(Self {
+                device: metadata.dev(),
+                inode: metadata.ino(),
+            })
+        }
+    }
+}

--- a/crates/sandbox-gateway/src/gateway/main.rs
+++ b/crates/sandbox-gateway/src/gateway/main.rs
@@ -40,7 +40,11 @@ enum Backend {
 
 #[derive(Debug, Args)]
 struct ServeCommand {
-    #[arg(long = "gateway-socket", value_name = "HOST:PORT")]
+    #[arg(
+        long = "gateway-endpoint",
+        visible_alias = "gateway-socket",
+        value_name = "ENDPOINT"
+    )]
     gateway_socket: Option<String>,
 
     #[arg(long = "auth-token", value_name = "TOKEN")]

--- a/crates/sandbox-gateway/src/gateway/mod.rs
+++ b/crates/sandbox-gateway/src/gateway/mod.rs
@@ -2,12 +2,13 @@ pub mod config;
 pub mod connection;
 pub mod error;
 pub mod lifecycle;
+mod listener;
 pub mod server;
 
 pub use config::{
-    resolve_gateway_config, GatewayCliOverrides, GatewayConfig, DEFAULT_GATEWAY_PID,
-    DEFAULT_GATEWAY_SOCKET, DEFAULT_MAX_CONCURRENT_CONNECTIONS, SANDBOX_GATEWAY_AUTH_TOKEN_ENV,
-    SANDBOX_GATEWAY_SOCKET_ENV,
+    resolve_gateway_config, GatewayCliOverrides, GatewayConfig, GatewayEndpoint,
+    GatewayEndpointParseError, DEFAULT_GATEWAY_PID, DEFAULT_GATEWAY_SOCKET,
+    DEFAULT_MAX_CONCURRENT_CONNECTIONS, SANDBOX_GATEWAY_AUTH_TOKEN_ENV, SANDBOX_GATEWAY_SOCKET_ENV,
 };
 pub use error::GatewayError;
 pub use server::SandboxGatewayServer;

--- a/crates/sandbox-gateway/src/lib.rs
+++ b/crates/sandbox-gateway/src/lib.rs
@@ -7,8 +7,9 @@ mod local_daemon_installer;
 
 pub use daemon_client::TcpSandboxDaemonClient;
 pub use gateway::{
-    resolve_gateway_config, GatewayCliOverrides, GatewayConfig, GatewayError, SandboxGatewayServer,
-    DEFAULT_GATEWAY_PID, DEFAULT_GATEWAY_SOCKET, DEFAULT_MAX_CONCURRENT_CONNECTIONS,
-    SANDBOX_GATEWAY_AUTH_TOKEN_ENV, SANDBOX_GATEWAY_SOCKET_ENV,
+    resolve_gateway_config, GatewayCliOverrides, GatewayConfig, GatewayEndpoint,
+    GatewayEndpointParseError, GatewayError, SandboxGatewayServer, DEFAULT_GATEWAY_PID,
+    DEFAULT_GATEWAY_SOCKET, DEFAULT_MAX_CONCURRENT_CONNECTIONS, SANDBOX_GATEWAY_AUTH_TOKEN_ENV,
+    SANDBOX_GATEWAY_SOCKET_ENV,
 };
 pub use local_daemon_installer::{LocalDaemonTimeouts, LocalSandboxDaemonInstaller};

--- a/crates/sandbox-gateway/tests/gateway_server.rs
+++ b/crates/sandbox-gateway/tests/gateway_server.rs
@@ -16,6 +16,10 @@ use sandbox_protocol::{error as wire_error, ProtocolLimits};
 use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
+#[cfg(unix)]
+use tokio::net::UnixStream;
+#[cfg(windows)]
+use tokio::{net::windows::named_pipe::ClientOptions, sync::Barrier, task::JoinSet};
 use tokio_util::sync::CancellationToken;
 
 type TestResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
@@ -253,6 +257,139 @@ async fn gateway_binds_tcp_writes_pid_file_and_cleans_up() -> TestResult {
     Ok(())
 }
 
+#[cfg(windows)]
+#[tokio::test]
+async fn gateway_named_pipe_accepts_concurrent_clients_without_retries() -> TestResult {
+    let root = unique_temp_dir("sandbox-gateway-pipe-test")?;
+    let pid_path = root.join("gateway.pid");
+    let sequence = TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pipe_name = format!("ephemeral-sandbox-test-{}-{sequence}", std::process::id());
+    let endpoint = format!("npipe://./pipe/{pipe_name}");
+    let native_path = format!(r"\\.\pipe\{pipe_name}");
+    let shutdown = CancellationToken::new();
+    let (services, _store, _daemon_client) = services();
+    let server = SandboxGatewayServer::with_shutdown(
+        GatewayConfig::new(endpoint, pid_path.clone(), 8, Some("pipe-token".to_owned())),
+        SandboxManagerRouter::new(services),
+        shutdown.clone(),
+    );
+    let handle = tokio::spawn(server.serve());
+
+    wait_for_path(&pid_path).await?;
+    let barrier = Arc::new(Barrier::new(6));
+    let mut clients = JoinSet::new();
+    for request_id in 0..5 {
+        let barrier = Arc::clone(&barrier);
+        let native_path = native_path.clone();
+        clients.spawn(async move {
+            barrier.wait().await;
+            let mut stream = ClientOptions::new().open(native_path)?;
+            let request = json!({
+                "op": "list_sandboxes",
+                "request_id": format!("pipe-{request_id}"),
+                "scope": OperationScope::System,
+                "args": {},
+                "_sandbox_gateway_auth_token": "pipe-token",
+            });
+            let mut raw = serde_json::to_vec(&request)?;
+            raw.push(b'\n');
+            stream.write_all(&raw).await?;
+            let mut response = String::new();
+            BufReader::new(stream).read_line(&mut response).await?;
+            Ok::<Value, Box<dyn std::error::Error + Send + Sync>>(serde_json::from_str(&response)?)
+        });
+    }
+    barrier.wait().await;
+
+    while let Some(result) = clients.join_next().await {
+        let response = result??;
+        assert_eq!(response["sandboxes"], json!([]));
+    }
+
+    shutdown.cancel();
+    handle.await??;
+    assert!(!pid_path.exists());
+    let _ = std::fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn gateway_unix_socket_is_owner_only_and_removed_on_shutdown() -> TestResult {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = unique_temp_dir("sandbox-gateway-unix-test")?;
+    let pid_path = root.join("gateway.pid");
+    let socket_path = root.join("gateway.sock");
+    let endpoint = format!("unix://{}", socket_path.display());
+    let shutdown = CancellationToken::new();
+    let (services, _store, _daemon_client) = services();
+    let server = SandboxGatewayServer::with_shutdown(
+        GatewayConfig::new(endpoint, pid_path.clone(), 8, Some("unix-token".to_owned())),
+        SandboxManagerRouter::new(services),
+        shutdown.clone(),
+    );
+    let handle = tokio::spawn(server.serve());
+
+    wait_for_path(&pid_path).await?;
+    assert_eq!(
+        std::fs::metadata(&socket_path)?.permissions().mode() & 0o777,
+        0o600
+    );
+    let mut stream = UnixStream::connect(&socket_path).await?;
+    let request = json!({
+        "op": "list_sandboxes",
+        "request_id": "unix-1",
+        "scope": OperationScope::System,
+        "args": {},
+        "_sandbox_gateway_auth_token": "unix-token",
+    });
+    let mut raw = serde_json::to_vec(&request)?;
+    raw.push(b'\n');
+    stream.write_all(&raw).await?;
+    let mut response = String::new();
+    BufReader::new(stream).read_line(&mut response).await?;
+    assert_eq!(
+        serde_json::from_str::<Value>(&response)?["sandboxes"],
+        json!([])
+    );
+
+    shutdown.cancel();
+    handle.await??;
+    assert!(!pid_path.exists());
+    assert!(!socket_path.exists());
+    let _ = std::fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn gateway_unix_socket_refuses_to_replace_existing_path() -> TestResult {
+    let root = unique_temp_dir("sandbox-gateway-unix-stale-test")?;
+    let socket_path = root.join("gateway.sock");
+    std::fs::write(&socket_path, b"preserve")?;
+    let (services, _store, _daemon_client) = services();
+    let server = server(
+        services,
+        format!("unix://{}", socket_path.display()),
+        root.join("gateway.pid"),
+        8,
+        CancellationToken::new(),
+    );
+
+    let error = server
+        .serve()
+        .await
+        .expect_err("existing path must prevent Unix socket bind");
+    assert!(
+        error.to_string().contains("already exists"),
+        "unexpected error: {error}"
+    );
+    assert_eq!(std::fs::read(&socket_path)?, b"preserve");
+    let _ = std::fs::remove_dir_all(root);
+    Ok(())
+}
+
 #[tokio::test]
 async fn gateway_connection_decodes_request_and_writes_response() -> TestResult {
     let (services, _store, _daemon_client) = services();
@@ -303,9 +440,11 @@ async fn gateway_streams_create_sandbox_progress_before_final_response() -> Test
     assert!(responses
         .iter()
         .any(|response| response.contains("building shared workspace base")));
-    assert!(responses.iter().any(
-        |response| response.contains(&format!("creating runtime sandbox for {workspace_root}"))
-    ));
+    let expected_runtime_progress =
+        serde_json::to_string(&format!("creating runtime sandbox for {workspace_root}"))?;
+    assert!(responses
+        .iter()
+        .any(|response| response.contains(&expected_runtime_progress)));
     let final_response = serde_json::from_str::<Value>(responses.last().expect("final response"))?;
     assert_eq!(final_response["id"], "container-1");
     assert_eq!(

--- a/crates/sandbox-gateway/tests/local_daemon_installer.rs
+++ b/crates/sandbox-gateway/tests/local_daemon_installer.rs
@@ -1,3 +1,5 @@
+#![cfg(unix)]
+
 use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::process::{Child, Command};

--- a/crates/sandbox-mcp/src/config.rs
+++ b/crates/sandbox-mcp/src/config.rs
@@ -16,7 +16,11 @@ pub struct Cli {
     #[arg(long, value_enum)]
     pub set: OperationSet,
 
-    #[arg(long = "gateway-socket", value_name = "HOST:PORT")]
+    #[arg(
+        long = "gateway-endpoint",
+        visible_alias = "gateway-socket",
+        value_name = "URI"
+    )]
     gateway_socket_path: Option<PathBuf>,
 
     #[arg(long = "gateway-auth-token", value_name = "TOKEN")]

--- a/crates/sandbox-mcp/src/lib.rs
+++ b/crates/sandbox-mcp/src/lib.rs
@@ -25,10 +25,7 @@ pub async fn run(
     gateway: GatewayConfig,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let catalog = selected_catalog(set)?;
-    let client = GatewayClient::new(
-        gateway.gateway_socket_path.to_string_lossy().into_owned(),
-        gateway.gateway_auth_token,
-    );
+    let client = GatewayClient::from_endpoint(gateway.gateway_endpoint, gateway.gateway_auth_token);
     let server = SandboxMcpServer::new(set, catalog, client)?;
     let service = server.serve(rmcp::transport::stdio()).await?;
     service.waiting().await?;

--- a/crates/sandbox-operations/client/src/client.rs
+++ b/crates/sandbox-operations/client/src/client.rs
@@ -4,16 +4,17 @@ use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 
-use crate::MAX_REQUEST_BYTES;
+use crate::{GatewayEndpoint, GatewayEndpointParseError, MAX_REQUEST_BYTES};
 
 #[derive(Debug)]
 pub struct GatewayClient {
-    addr: String,
+    endpoint: Result<GatewayEndpoint, GatewayEndpointParseError>,
     auth_token: Option<String>,
 }
 
 #[derive(Debug)]
 pub enum GatewayClientError {
+    Endpoint(GatewayEndpointParseError),
     Transport(std::io::Error),
     Protocol(String),
     Json(serde_json::Error),
@@ -21,9 +22,17 @@ pub enum GatewayClientError {
 
 impl GatewayClient {
     #[must_use]
-    pub fn new(addr: impl Into<String>, auth_token: Option<String>) -> Self {
+    pub fn new(endpoint: impl Into<String>, auth_token: Option<String>) -> Self {
         Self {
-            addr: addr.into(),
+            endpoint: GatewayEndpoint::parse(&endpoint.into()),
+            auth_token,
+        }
+    }
+
+    #[must_use]
+    pub const fn from_endpoint(endpoint: GatewayEndpoint, auth_token: Option<String>) -> Self {
+        Self {
+            endpoint: Ok(endpoint),
             auth_token,
         }
     }
@@ -42,7 +51,11 @@ impl GatewayClient {
         F: FnMut(&str),
     {
         let request_line = request_line(request, self.auth_token.as_deref(), stream_logs)?;
-        let mut stream = TcpStream::connect(self.addr.as_str())
+        let endpoint = self
+            .endpoint
+            .as_ref()
+            .map_err(|error| GatewayClientError::Endpoint(error.clone()))?;
+        let mut stream = connect(endpoint)
             .await
             .map_err(GatewayClientError::Transport)?;
         stream
@@ -65,7 +78,7 @@ impl GatewayClientError {
     #[must_use]
     pub const fn kind(&self) -> &'static str {
         match self {
-            Self::Transport(_) => "connection_error",
+            Self::Endpoint(_) | Self::Transport(_) => "connection_error",
             Self::Protocol(_) | Self::Json(_) => "protocol_error",
         }
     }
@@ -74,6 +87,7 @@ impl GatewayClientError {
 impl std::fmt::Display for GatewayClientError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Endpoint(error) => write!(formatter, "invalid gateway endpoint: {error}"),
             Self::Transport(error) => write!(formatter, "gateway connection failed: {error}"),
             Self::Protocol(message) => formatter.write_str(message),
             Self::Json(error) => write!(formatter, "gateway response json failed: {error}"),
@@ -82,6 +96,54 @@ impl std::fmt::Display for GatewayClientError {
 }
 
 impl std::error::Error for GatewayClientError {}
+
+trait GatewayIo: AsyncRead + tokio::io::AsyncWrite + Unpin + Send {}
+
+impl<T> GatewayIo for T where T: AsyncRead + tokio::io::AsyncWrite + Unpin + Send {}
+
+type GatewayStream = Box<dyn GatewayIo>;
+
+async fn connect(endpoint: &GatewayEndpoint) -> std::io::Result<GatewayStream> {
+    match endpoint {
+        GatewayEndpoint::Tcp(address) => TcpStream::connect(address)
+            .await
+            .map(|stream| Box::new(stream) as GatewayStream),
+        GatewayEndpoint::WindowsNamedPipe(path) => connect_windows_named_pipe(path).await,
+        GatewayEndpoint::UnixSocket(path) => connect_unix_socket(path).await,
+    }
+}
+
+#[cfg(windows)]
+async fn connect_windows_named_pipe(path: &str) -> std::io::Result<GatewayStream> {
+    use tokio::net::windows::named_pipe::ClientOptions;
+
+    ClientOptions::new()
+        .open(path)
+        .map(|stream| Box::new(stream) as GatewayStream)
+}
+
+#[cfg(not(windows))]
+async fn connect_windows_named_pipe(_path: &str) -> std::io::Result<GatewayStream> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "Windows named-pipe gateway endpoints are unavailable on this platform",
+    ))
+}
+
+#[cfg(unix)]
+async fn connect_unix_socket(path: &std::path::Path) -> std::io::Result<GatewayStream> {
+    tokio::net::UnixStream::connect(path)
+        .await
+        .map(|stream| Box::new(stream) as GatewayStream)
+}
+
+#[cfg(not(unix))]
+async fn connect_unix_socket(_path: &std::path::Path) -> std::io::Result<GatewayStream> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "Unix-domain gateway endpoints are unavailable on this platform",
+    ))
+}
 
 fn request_line(
     request: &OperationRequest,

--- a/crates/sandbox-operations/client/src/client.rs
+++ b/crates/sandbox-operations/client/src/client.rs
@@ -108,6 +108,9 @@ async fn connect(endpoint: &GatewayEndpoint) -> std::io::Result<GatewayStream> {
         GatewayEndpoint::Tcp(address) => TcpStream::connect(address)
             .await
             .map(|stream| Box::new(stream) as GatewayStream),
+        GatewayEndpoint::TcpHost(address) => TcpStream::connect(address.as_str())
+            .await
+            .map(|stream| Box::new(stream) as GatewayStream),
         GatewayEndpoint::WindowsNamedPipe(path) => connect_windows_named_pipe(path).await,
         GatewayEndpoint::UnixSocket(path) => connect_unix_socket(path).await,
     }

--- a/crates/sandbox-operations/client/src/config.rs
+++ b/crates/sandbox-operations/client/src/config.rs
@@ -3,13 +3,19 @@
 use std::ffi::OsString;
 use std::path::PathBuf;
 
+use crate::GatewayEndpoint;
+
 pub const SANDBOX_GATEWAY_SOCKET_ENV: &str = "SANDBOX_GATEWAY_SOCKET";
 pub const SANDBOX_GATEWAY_AUTH_TOKEN_ENV: &str = "SANDBOX_GATEWAY_AUTH_TOKEN";
+#[cfg(windows)]
+pub const DEFAULT_GATEWAY_SOCKET: &str = "npipe://./pipe/ephemeral-sandbox-gateway";
+#[cfg(not(windows))]
 pub const DEFAULT_GATEWAY_SOCKET: &str = "127.0.0.1:7878";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GatewayConfig {
     pub gateway_socket_path: PathBuf,
+    pub gateway_endpoint: GatewayEndpoint,
     pub gateway_auth_token: Option<String>,
 }
 
@@ -63,6 +69,8 @@ impl GatewayConfig {
         if gateway_socket_path.as_os_str().is_empty() {
             return Err(config_error("gateway socket path must be non-empty"));
         }
+        let gateway_endpoint = GatewayEndpoint::parse(&gateway_socket_path.to_string_lossy())
+            .map_err(|error| config_error(format!("invalid gateway endpoint: {error}")))?;
 
         let gateway_auth_token = overrides
             .gateway_auth_token
@@ -72,6 +80,7 @@ impl GatewayConfig {
 
         Ok(Self {
             gateway_socket_path,
+            gateway_endpoint,
             gateway_auth_token,
         })
     }

--- a/crates/sandbox-operations/client/src/endpoint.rs
+++ b/crates/sandbox-operations/client/src/endpoint.rs
@@ -10,6 +10,7 @@ const UNIX_SOCKET_SCHEME: &str = "unix://";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GatewayEndpoint {
     Tcp(SocketAddr),
+    TcpHost(String),
     WindowsNamedPipe(String),
     UnixSocket(PathBuf),
 }
@@ -90,6 +91,7 @@ impl std::fmt::Display for GatewayEndpoint {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Tcp(address) => write!(formatter, "{TCP_SCHEME}{address}"),
+            Self::TcpHost(address) => write!(formatter, "{TCP_SCHEME}{address}"),
             Self::WindowsNamedPipe(path) => {
                 let name = path.strip_prefix(WINDOWS_NAMED_PIPE_PREFIX).unwrap_or(path);
                 write!(
@@ -114,13 +116,33 @@ impl std::fmt::Display for GatewayEndpointParseError {
 impl std::error::Error for GatewayEndpointParseError {}
 
 fn parse_tcp_address(value: &str) -> Result<GatewayEndpoint, GatewayEndpointParseError> {
-    let address = value
-        .parse::<SocketAddr>()
-        .map_err(|_| endpoint_error("TCP gateway endpoint must be a valid IP socket address"))?;
-    if address.port() == 0 {
+    if let Ok(address) = value.parse::<SocketAddr>() {
+        if address.port() == 0 {
+            return Err(endpoint_error("TCP gateway endpoint port must be non-zero"));
+        }
+        return Ok(GatewayEndpoint::Tcp(address));
+    }
+    let Some((host, port)) = value.rsplit_once(':') else {
+        return Err(endpoint_error(
+            "TCP gateway endpoint must be a valid host:port address",
+        ));
+    };
+    if host.is_empty()
+        || host
+            .chars()
+            .any(|character| character.is_whitespace() || matches!(character, ':' | '/' | '\\'))
+    {
+        return Err(endpoint_error(
+            "TCP gateway endpoint must be a valid host:port address",
+        ));
+    }
+    let port = port
+        .parse::<u16>()
+        .map_err(|_| endpoint_error("TCP gateway endpoint must be a valid host:port address"))?;
+    if port == 0 {
         return Err(endpoint_error("TCP gateway endpoint port must be non-zero"));
     }
-    Ok(GatewayEndpoint::Tcp(address))
+    Ok(GatewayEndpoint::TcpHost(format!("{host}:{port}")))
 }
 
 fn parse_unix_socket_path(value: &str) -> Result<GatewayEndpoint, GatewayEndpointParseError> {

--- a/crates/sandbox-operations/client/src/endpoint.rs
+++ b/crates/sandbox-operations/client/src/endpoint.rs
@@ -1,0 +1,190 @@
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+const TCP_SCHEME: &str = "tcp://";
+const WINDOWS_NAMED_PIPE_SCHEME: &str = "npipe://./pipe/";
+const WINDOWS_NAMED_PIPE_PREFIX: &str = r"\\.\pipe\";
+const UNIX_SOCKET_SCHEME: &str = "unix://";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GatewayEndpoint {
+    Tcp(SocketAddr),
+    WindowsNamedPipe(String),
+    UnixSocket(PathBuf),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatewayEndpointParseError {
+    message: String,
+}
+
+impl GatewayEndpoint {
+    /// Parse an explicit gateway endpoint URI or a legacy TCP socket address.
+    ///
+    /// # Errors
+    /// Returns an error when the endpoint syntax, address, or path is invalid.
+    pub fn parse(value: &str) -> Result<Self, GatewayEndpointParseError> {
+        value.parse()
+    }
+
+    #[must_use]
+    pub fn tcp(address: SocketAddr) -> Self {
+        Self::Tcp(address)
+    }
+
+    /// Construct a gateway endpoint from a canonical Windows named-pipe path.
+    ///
+    /// # Errors
+    /// Returns an error when the path is outside the local named-pipe namespace.
+    pub fn windows_named_pipe(path: impl Into<String>) -> Result<Self, GatewayEndpointParseError> {
+        let path = path.into();
+        let Some(name) = path.strip_prefix(WINDOWS_NAMED_PIPE_PREFIX) else {
+            return Err(endpoint_error(
+                "Windows named-pipe path must start with \\\\.\\pipe\\",
+            ));
+        };
+        parse_named_pipe_name(name, '\\')
+    }
+
+    /// Construct a gateway endpoint from an absolute Unix-domain socket path.
+    ///
+    /// # Errors
+    /// Returns an error when the path is not absolute or has unsafe segments.
+    pub fn unix_socket(path: impl Into<PathBuf>) -> Result<Self, GatewayEndpointParseError> {
+        let path = path.into();
+        let path_text = path.to_string_lossy();
+        parse_unix_socket_path(&path_text)
+    }
+}
+
+impl FromStr for GatewayEndpoint {
+    type Err = GatewayEndpointParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.is_empty() {
+            return Err(endpoint_error("gateway endpoint must be non-empty"));
+        }
+        if value.trim() != value {
+            return Err(endpoint_error(
+                "gateway endpoint must not contain surrounding whitespace",
+            ));
+        }
+        if let Some(address) = value.strip_prefix(TCP_SCHEME) {
+            return parse_tcp_address(address);
+        }
+        if let Some(name) = value.strip_prefix(WINDOWS_NAMED_PIPE_SCHEME) {
+            return parse_named_pipe_name(name, '/');
+        }
+        if let Some(path) = value.strip_prefix(UNIX_SOCKET_SCHEME) {
+            return parse_unix_socket_path(path);
+        }
+        if value.contains("://") {
+            return Err(endpoint_error("unsupported gateway endpoint scheme"));
+        }
+        parse_tcp_address(value)
+    }
+}
+
+impl std::fmt::Display for GatewayEndpoint {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Tcp(address) => write!(formatter, "{TCP_SCHEME}{address}"),
+            Self::WindowsNamedPipe(path) => {
+                let name = path.strip_prefix(WINDOWS_NAMED_PIPE_PREFIX).unwrap_or(path);
+                write!(
+                    formatter,
+                    "{WINDOWS_NAMED_PIPE_SCHEME}{}",
+                    name.replace('\\', "/")
+                )
+            }
+            Self::UnixSocket(path) => {
+                write!(formatter, "{UNIX_SOCKET_SCHEME}{}", path.display())
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for GatewayEndpointParseError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for GatewayEndpointParseError {}
+
+fn parse_tcp_address(value: &str) -> Result<GatewayEndpoint, GatewayEndpointParseError> {
+    let address = value
+        .parse::<SocketAddr>()
+        .map_err(|_| endpoint_error("TCP gateway endpoint must be a valid IP socket address"))?;
+    if address.port() == 0 {
+        return Err(endpoint_error("TCP gateway endpoint port must be non-zero"));
+    }
+    Ok(GatewayEndpoint::Tcp(address))
+}
+
+fn parse_unix_socket_path(value: &str) -> Result<GatewayEndpoint, GatewayEndpointParseError> {
+    let Some(name) = value.strip_prefix('/') else {
+        return Err(endpoint_error("Unix-domain socket path must be absolute"));
+    };
+    validate_path_segments(name.split('/'), "Unix-domain socket")?;
+    if value.len() > 100 {
+        return Err(endpoint_error(
+            "Unix-domain socket path exceeds the portable 100-byte limit",
+        ));
+    }
+    if value.chars().any(char::is_control) || value.contains('\\') {
+        return Err(endpoint_error(
+            "Unix-domain socket path contains an unsafe character",
+        ));
+    }
+    Ok(GatewayEndpoint::UnixSocket(PathBuf::from(value)))
+}
+
+fn parse_named_pipe_name(
+    name: &str,
+    separator: char,
+) -> Result<GatewayEndpoint, GatewayEndpointParseError> {
+    validate_path_segments(name.split(separator), "Windows named-pipe")?;
+    if name.chars().any(|character| {
+        !character.is_ascii_alphanumeric()
+            && character != separator
+            && !matches!(character, '-' | '_' | '.')
+    }) {
+        return Err(endpoint_error(
+            "Windows named-pipe name contains an unsafe character",
+        ));
+    }
+    let path = format!("{WINDOWS_NAMED_PIPE_PREFIX}{}", name.replace('/', "\\"));
+    if path.encode_utf16().count() > 256 {
+        return Err(endpoint_error(
+            "Windows named-pipe path exceeds the 256-character limit",
+        ));
+    }
+    Ok(GatewayEndpoint::WindowsNamedPipe(path))
+}
+
+fn validate_path_segments<'a>(
+    segments: impl Iterator<Item = &'a str>,
+    transport: &str,
+) -> Result<(), GatewayEndpointParseError> {
+    for segment in segments {
+        if segment.is_empty() {
+            return Err(endpoint_error(format!(
+                "{transport} path must not contain empty segments"
+            )));
+        }
+        if matches!(segment, "." | "..") {
+            return Err(endpoint_error(format!(
+                "{transport} path must not contain dot segments"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn endpoint_error(message: impl Into<String>) -> GatewayEndpointParseError {
+    GatewayEndpointParseError {
+        message: message.into(),
+    }
+}

--- a/crates/sandbox-operations/client/src/lib.rs
+++ b/crates/sandbox-operations/client/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod client;
 mod config;
+mod endpoint;
 mod request;
 
 pub use client::{GatewayClient, GatewayClientError};
@@ -10,6 +11,7 @@ pub use config::{
     ConfigError, GatewayConfig, GatewayConfigOverrides, DEFAULT_GATEWAY_SOCKET,
     SANDBOX_GATEWAY_AUTH_TOKEN_ENV, SANDBOX_GATEWAY_SOCKET_ENV,
 };
+pub use endpoint::{GatewayEndpoint, GatewayEndpointParseError};
 pub use request::{
     build_request_from_values, build_request_from_values_with_id, catalog_arg_default,
     BuildRequestValueInput, RequestBuildError,

--- a/crates/sandbox-operations/client/tests/config.rs
+++ b/crates/sandbox-operations/client/tests/config.rs
@@ -2,8 +2,8 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 
 use sandbox_operation_client::{
-    GatewayConfig, GatewayConfigOverrides, DEFAULT_GATEWAY_SOCKET, SANDBOX_GATEWAY_AUTH_TOKEN_ENV,
-    SANDBOX_GATEWAY_SOCKET_ENV,
+    GatewayConfig, GatewayConfigOverrides, GatewayEndpoint, DEFAULT_GATEWAY_SOCKET,
+    SANDBOX_GATEWAY_AUTH_TOKEN_ENV, SANDBOX_GATEWAY_SOCKET_ENV,
 };
 
 #[test]
@@ -14,23 +14,27 @@ fn config_precedence_is_override_environment_default() {
         default_config.gateway_socket_path,
         PathBuf::from(DEFAULT_GATEWAY_SOCKET)
     );
+    assert_eq!(
+        default_config.gateway_endpoint,
+        GatewayEndpoint::parse(DEFAULT_GATEWAY_SOCKET).expect("default endpoint")
+    );
 
     let env_config =
         GatewayConfig::discover_with(GatewayConfigOverrides::default(), |key| match key {
-            SANDBOX_GATEWAY_SOCKET_ENV => Some(OsString::from("/env/gateway.sock")),
+            SANDBOX_GATEWAY_SOCKET_ENV => Some(OsString::from("unix:///env/gateway.sock")),
             SANDBOX_GATEWAY_AUTH_TOKEN_ENV => Some(OsString::from("env-token")),
             _ => None,
         })
         .expect("environment config discovers");
     assert_eq!(
         env_config.gateway_socket_path,
-        PathBuf::from("/env/gateway.sock")
+        PathBuf::from("unix:///env/gateway.sock")
     );
     assert_eq!(env_config.gateway_auth_token.as_deref(), Some("env-token"));
 
     let override_config = GatewayConfig::discover_with(
         GatewayConfigOverrides {
-            gateway_socket_path: Some(PathBuf::from("/override/gateway.sock")),
+            gateway_socket_path: Some(PathBuf::from("npipe://./pipe/override/gateway")),
             gateway_auth_token: Some("override-token".to_owned()),
         },
         |_| None,
@@ -38,7 +42,7 @@ fn config_precedence_is_override_environment_default() {
     .expect("overrides discover");
     assert_eq!(
         override_config.gateway_socket_path,
-        PathBuf::from("/override/gateway.sock")
+        PathBuf::from("npipe://./pipe/override/gateway")
     );
     assert_eq!(
         override_config.gateway_auth_token.as_deref(),

--- a/crates/sandbox-operations/client/tests/endpoint.rs
+++ b/crates/sandbox-operations/client/tests/endpoint.rs
@@ -1,0 +1,135 @@
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::path::PathBuf;
+
+use sandbox_operation_client::{GatewayEndpoint, GatewayEndpointParseError};
+
+#[test]
+fn parses_explicit_and_legacy_tcp_endpoints() {
+    let ipv4 = SocketAddr::from((Ipv4Addr::LOCALHOST, 7878));
+    let ipv6 = SocketAddr::from((Ipv6Addr::LOCALHOST, 7878));
+
+    assert_eq!(
+        GatewayEndpoint::parse("tcp://127.0.0.1:7878").expect("explicit IPv4"),
+        GatewayEndpoint::Tcp(ipv4)
+    );
+    assert_eq!(
+        GatewayEndpoint::parse("127.0.0.1:7878").expect("legacy IPv4"),
+        GatewayEndpoint::Tcp(ipv4)
+    );
+    assert_eq!(
+        GatewayEndpoint::parse("tcp://[::1]:7878").expect("explicit IPv6"),
+        GatewayEndpoint::Tcp(ipv6)
+    );
+}
+
+#[test]
+fn parses_local_ipc_endpoints_to_native_paths() {
+    let named_pipe =
+        GatewayEndpoint::parse("npipe://./pipe/ephemeral-sandbox/gateway").expect("named pipe");
+    let unix_socket = GatewayEndpoint::parse("unix:///run/user/1000/ephemeral-sandbox.sock")
+        .expect("Unix socket");
+
+    assert_eq!(
+        named_pipe,
+        GatewayEndpoint::WindowsNamedPipe(r"\\.\pipe\ephemeral-sandbox\gateway".to_owned())
+    );
+    assert_eq!(
+        unix_socket,
+        GatewayEndpoint::UnixSocket(PathBuf::from("/run/user/1000/ephemeral-sandbox.sock"))
+    );
+    assert_eq!(
+        named_pipe.to_string(),
+        "npipe://./pipe/ephemeral-sandbox/gateway"
+    );
+    assert_eq!(
+        unix_socket.to_string(),
+        "unix:///run/user/1000/ephemeral-sandbox.sock"
+    );
+}
+
+#[test]
+fn endpoint_constructors_validate_local_paths() {
+    assert_eq!(
+        GatewayEndpoint::windows_named_pipe(r"\\.\pipe\gateway").expect("native pipe"),
+        GatewayEndpoint::WindowsNamedPipe(r"\\.\pipe\gateway".to_owned())
+    );
+    assert_eq!(
+        GatewayEndpoint::unix_socket("/tmp/gateway.sock").expect("absolute Unix path"),
+        GatewayEndpoint::UnixSocket(PathBuf::from("/tmp/gateway.sock"))
+    );
+    assert!(GatewayEndpoint::windows_named_pipe(r"\\.\pipe\gateway/name").is_err());
+}
+
+#[test]
+fn rejects_invalid_endpoint_syntax() {
+    let cases = [
+        ("", "gateway endpoint must be non-empty"),
+        (
+            "http://127.0.0.1:7878",
+            "unsupported gateway endpoint scheme",
+        ),
+        (
+            "tcp://localhost:7878",
+            "TCP gateway endpoint must be a valid IP socket address",
+        ),
+        (
+            "tcp://127.0.0.1:0",
+            "TCP gateway endpoint port must be non-zero",
+        ),
+        (
+            " tcp://127.0.0.1:7878",
+            "gateway endpoint must not contain surrounding whitespace",
+        ),
+        (
+            "npipe://./pipe/gateway/../other",
+            "Windows named-pipe path must not contain dot segments",
+        ),
+        (
+            "npipe://./pipe/gateway:other",
+            "Windows named-pipe name contains an unsafe character",
+        ),
+        (
+            r"npipe://./pipe/gateway\other",
+            "Windows named-pipe name contains an unsafe character",
+        ),
+        (
+            "unix://relative.sock",
+            "Unix-domain socket path must be absolute",
+        ),
+        (
+            "unix:///tmp//gateway.sock",
+            "Unix-domain socket path must not contain empty segments",
+        ),
+        (
+            "unix:///tmp/gateway\\other.sock",
+            "Unix-domain socket path contains an unsafe character",
+        ),
+    ];
+
+    for (value, expected) in cases {
+        let error: GatewayEndpointParseError =
+            GatewayEndpoint::parse(value).expect_err("endpoint is invalid");
+        assert_eq!(error.to_string(), expected);
+    }
+}
+
+#[test]
+fn rejects_local_ipc_paths_over_the_transport_limits() {
+    let pipe_name = "a".repeat(250);
+    let pipe = format!("npipe://./pipe/{pipe_name}");
+    assert_eq!(
+        GatewayEndpoint::parse(&pipe)
+            .expect_err("named-pipe path is too long")
+            .to_string(),
+        "Windows named-pipe path exceeds the 256-character limit"
+    );
+
+    let socket_name = "a".repeat(96);
+    let socket = format!("unix:///tmp/{socket_name}");
+    assert_eq!(
+        GatewayEndpoint::parse(&socket)
+            .expect_err("Unix-domain socket path is too long")
+            .to_string(),
+        "Unix-domain socket path exceeds the portable 100-byte limit"
+    );
+}

--- a/crates/sandbox-operations/client/tests/endpoint.rs
+++ b/crates/sandbox-operations/client/tests/endpoint.rs
@@ -20,6 +20,10 @@ fn parses_explicit_and_legacy_tcp_endpoints() {
         GatewayEndpoint::parse("tcp://[::1]:7878").expect("explicit IPv6"),
         GatewayEndpoint::Tcp(ipv6)
     );
+    assert_eq!(
+        GatewayEndpoint::parse("tcp://localhost:7878").expect("DNS host"),
+        GatewayEndpoint::TcpHost("localhost:7878".to_owned())
+    );
 }
 
 #[test]
@@ -69,8 +73,8 @@ fn rejects_invalid_endpoint_syntax() {
             "unsupported gateway endpoint scheme",
         ),
         (
-            "tcp://localhost:7878",
-            "TCP gateway endpoint must be a valid IP socket address",
+            "tcp://localhost",
+            "TCP gateway endpoint must be a valid host:port address",
         ),
         (
             "tcp://127.0.0.1:0",
@@ -98,6 +102,10 @@ fn rejects_invalid_endpoint_syntax() {
         ),
         (
             "unix:///tmp//gateway.sock",
+            "Unix-domain socket path must not contain empty segments",
+        ),
+        (
+            "unix:////tmp/gateway.sock",
             "Unix-domain socket path must not contain empty segments",
         ),
         (

--- a/crates/sandbox-operations/client/tests/transport.rs
+++ b/crates/sandbox-operations/client/tests/transport.rs
@@ -78,3 +78,169 @@ async fn oversized_encoded_request_is_rejected_before_connection() {
         format!("gateway request exceeded {MAX_REQUEST_BYTES} bytes")
     );
 }
+
+#[tokio::test]
+async fn explicit_tcp_endpoint_uses_the_shared_transport() {
+    let (addr, worker) = gateway(b"{\"transport\":\"tcp\"}\n".to_vec()).await;
+    let client = GatewayClient::new(format!("tcp://{addr}"), None);
+    let response = client.send(&request(json!({}))).await.expect("response");
+    worker.await.expect("gateway task");
+
+    assert_eq!(response, json!({"transport": "tcp"}));
+}
+
+#[tokio::test]
+async fn invalid_endpoint_fails_before_transport_connection() {
+    let client = GatewayClient::new("http://127.0.0.1:7878", None);
+    let error = client
+        .send(&request(json!({})))
+        .await
+        .expect_err("invalid endpoint");
+
+    assert!(matches!(&error, GatewayClientError::Endpoint(_)));
+    assert_eq!(error.kind(), "connection_error");
+    assert_eq!(
+        error.to_string(),
+        "invalid gateway endpoint: unsupported gateway endpoint scheme"
+    );
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn named_pipe_endpoint_round_trips_a_gateway_request() {
+    use sandbox_operation_client::GatewayEndpoint;
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    use tokio::net::windows::named_pipe::ServerOptions;
+
+    let pipe_path = format!(
+        r"\\.\pipe\sandbox-operation-client-{}",
+        uuid::Uuid::new_v4()
+    );
+    let server = ServerOptions::new()
+        .first_pipe_instance(true)
+        .create(&pipe_path)
+        .expect("create named pipe");
+    let worker = tokio::spawn(async move {
+        server.connect().await.expect("connect named-pipe client");
+        let mut reader = BufReader::new(server);
+        let mut request = Vec::new();
+        reader
+            .read_until(b'\n', &mut request)
+            .await
+            .expect("read request");
+        reader
+            .get_mut()
+            .write_all(b"{\"transport\":\"npipe\"}\n")
+            .await
+            .expect("write response");
+        serde_json::from_slice::<Value>(&request).expect("request JSON")
+    });
+    let endpoint = GatewayEndpoint::windows_named_pipe(pipe_path).expect("named-pipe endpoint");
+    let client = GatewayClient::from_endpoint(endpoint, None);
+    let response = client.send(&request(json!({}))).await.expect("response");
+    let received = worker.await.expect("gateway task");
+
+    assert_eq!(response, json!({"transport": "npipe"}));
+    assert_eq!(received["op"], "list_sandboxes");
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn named_pipe_endpoint_handles_concurrency_five_bursts() {
+    use sandbox_operation_client::GatewayEndpoint;
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    use tokio::net::windows::named_pipe::ServerOptions;
+
+    const CLIENTS: usize = 5;
+
+    let pipe_path = format!(
+        r"\\.\pipe\sandbox-operation-client-burst-{}",
+        uuid::Uuid::new_v4()
+    );
+    let first_server = ServerOptions::new()
+        .first_pipe_instance(true)
+        .create(&pipe_path)
+        .expect("create first named-pipe instance");
+    let mut servers = vec![first_server];
+    for _ in 1..CLIENTS {
+        servers.push(
+            ServerOptions::new()
+                .create(&pipe_path)
+                .expect("create pending named-pipe instance"),
+        );
+    }
+    let worker = tokio::spawn(async move {
+        let mut handlers = Vec::with_capacity(CLIENTS);
+        for server in servers {
+            handlers.push(tokio::spawn(async move {
+                server.connect().await.expect("connect named-pipe client");
+                let mut reader = BufReader::new(server);
+                let mut request = Vec::new();
+                reader
+                    .read_until(b'\n', &mut request)
+                    .await
+                    .expect("read request");
+                reader
+                    .get_mut()
+                    .write_all(b"{\"transport\":\"npipe\"}\n")
+                    .await
+                    .expect("write response");
+            }));
+        }
+        for handler in handlers {
+            handler.await.expect("named-pipe handler");
+        }
+    });
+    let endpoint = GatewayEndpoint::windows_named_pipe(pipe_path).expect("named-pipe endpoint");
+    let mut clients = Vec::new();
+    for _ in 0..CLIENTS {
+        let client = GatewayClient::from_endpoint(endpoint.clone(), None);
+        clients.push(tokio::spawn(async move {
+            client.send(&request(json!({}))).await.expect("response")
+        }));
+    }
+    for client in clients {
+        assert_eq!(
+            client.await.expect("client task"),
+            json!({"transport": "npipe"})
+        );
+    }
+    worker.await.expect("gateway task");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn unix_socket_endpoint_round_trips_a_gateway_request() {
+    use sandbox_operation_client::GatewayEndpoint;
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    use tokio::net::UnixListener;
+
+    let socket_path = std::env::temp_dir().join(format!(
+        "sandbox-operation-client-{}.sock",
+        uuid::Uuid::new_v4()
+    ));
+    let listener = UnixListener::bind(&socket_path).expect("bind Unix socket");
+    let worker = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept client");
+        let mut reader = BufReader::new(stream);
+        let mut request = Vec::new();
+        reader
+            .read_until(b'\n', &mut request)
+            .await
+            .expect("read request");
+        reader
+            .get_mut()
+            .write_all(b"{\"transport\":\"unix\"}\n")
+            .await
+            .expect("write response");
+        serde_json::from_slice::<Value>(&request).expect("request JSON")
+    });
+    let endpoint = GatewayEndpoint::unix_socket(&socket_path).expect("Unix endpoint");
+    let client = GatewayClient::from_endpoint(endpoint, None);
+    let response = client.send(&request(json!({}))).await.expect("response");
+    let received = worker.await.expect("gateway task");
+    std::fs::remove_file(&socket_path).expect("remove Unix socket");
+
+    assert_eq!(response, json!({"transport": "unix"}));
+    assert_eq!(received["op"], "list_sandboxes");
+}

--- a/crates/sandbox-operations/client/tests/transport.rs
+++ b/crates/sandbox-operations/client/tests/transport.rs
@@ -90,6 +90,20 @@ async fn explicit_tcp_endpoint_uses_the_shared_transport() {
 }
 
 #[tokio::test]
+async fn legacy_dns_tcp_endpoint_remains_supported() {
+    let (addr, worker) = gateway(b"{\"transport\":\"tcp-dns\"}\n".to_vec()).await;
+    let port = addr
+        .parse::<std::net::SocketAddr>()
+        .expect("fake gateway address")
+        .port();
+    let client = GatewayClient::new(format!("localhost:{port}"), None);
+    let response = client.send(&request(json!({}))).await.expect("response");
+    worker.await.expect("gateway task");
+
+    assert_eq!(response, json!({"transport": "tcp-dns"}));
+}
+
+#[tokio::test]
 async fn invalid_endpoint_fails_before_transport_connection() {
     let client = GatewayClient::new("http://127.0.0.1:7878", None);
     let error = client

--- a/docs/windows-setup.md
+++ b/docs/windows-setup.md
@@ -84,7 +84,7 @@ Set-Content target\windows-gateway.token $env:SANDBOX_GATEWAY_AUTH_TOKEN
 target\debug\sandbox-gateway.exe serve `
   --backend docker `
   --config-yaml config\windows-amd64.yml `
-  --gateway-socket 127.0.0.1:7878 `
+  --gateway-endpoint npipe://./pipe/ephemeral-sandbox-gateway `
   --auth-token $env:SANDBOX_GATEWAY_AUTH_TOKEN `
   --pid-file target\windows-gateway.pid
 ```
@@ -108,12 +108,12 @@ if (-not $smoke) {
 }
 
 target\debug\sandbox-manager-cli.exe `
-  --gateway-socket 127.0.0.1:7878 `
+  --gateway-endpoint npipe://./pipe/ephemeral-sandbox-gateway `
   --gateway-auth-token $env:SANDBOX_GATEWAY_AUTH_TOKEN `
   list_docker_images
 
 $created = target\debug\sandbox-manager-cli.exe `
-  --gateway-socket 127.0.0.1:7878 `
+  --gateway-endpoint npipe://./pipe/ephemeral-sandbox-gateway `
   --gateway-auth-token $env:SANDBOX_GATEWAY_AUTH_TOKEN `
   create_sandbox `
   --image alpine:3.20 `
@@ -122,13 +122,13 @@ $created = target\debug\sandbox-manager-cli.exe `
 $sandboxId = ($created | ConvertFrom-Json).id
 
 target\debug\sandbox-runtime-cli.exe `
-  --gateway-socket 127.0.0.1:7878 `
+  --gateway-endpoint npipe://./pipe/ephemeral-sandbox-gateway `
   --gateway-auth-token $env:SANDBOX_GATEWAY_AUTH_TOKEN `
   --sandbox-id $sandboxId `
   exec_command "pwd && cat README.txt && ls src"
 
 target\debug\sandbox-observability-cli.exe `
-  --gateway-socket 127.0.0.1:7878 `
+  --gateway-endpoint npipe://./pipe/ephemeral-sandbox-gateway `
   --gateway-auth-token $env:SANDBOX_GATEWAY_AUTH_TOKEN `
   snapshot --sandbox-id $sandboxId
 ```
@@ -139,6 +139,9 @@ workspace`, and `main.txt`.
 ## Run The Web Console
 
 The browser UI lives in the separate console repository.
+The console currently uses TCP, so stop the named-pipe gateway and restart the
+packaged launcher with
+`-GatewaySocket tcp://127.0.0.1:7878` before starting the console.
 
 ```powershell
 cd ..


### PR DESCRIPTION
## Summary

- use a local Windows named-pipe gateway endpoint by default
- add typed TCP, named-pipe, and Unix-socket endpoint handling to the gateway and client
- retain `--gateway-socket` as an alias and preserve TCP endpoints for the web console and existing clients
- update the Windows launcher, release instructions, and transport regression coverage

## Why

The Windows gateway previously assumed a loopback TCP socket. This introduces a local IPC default while retaining explicit TCP compatibility where that transport is required.

## Validation

- `cargo test -p sandbox-operation-client`
- `cargo test -p sandbox-config`
- `cargo test -p sandbox-gateway --test gateway_server`
- `cargo test -p sandbox-cli --test manager`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

The endpoint transport tests include a named-pipe request/response round trip and a five-client concurrent burst on Windows.