### PR TITLE
feat(windows): complete Windows x64 host build and CI

### DIFF
--- a/.github/workflows/ci-windows-amd64.yml
+++ b/.github/workflows/ci-windows-amd64.yml
@@ -1,0 +1,67 @@
+name: CI Windows amd64
+
+on:
+  push:
+    paths:
+      - crates/**
+      - Cargo.toml
+      - Cargo.lock
+      - .github/workflows/ci-windows-amd64.yml
+      - bin/**
+  pull_request:
+    paths:
+      - crates/**
+      - Cargo.toml
+      - Cargo.lock
+      - .github/workflows/ci-windows-amd64.yml
+      - bin/**
+
+permissions:
+  contents: read
+
+jobs:
+  ci-windows-amd64:
+    runs-on: windows-2022
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        shell: pwsh
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup component add --toolchain stable clippy rustfmt
+
+      - name: Build gateway
+        shell: pwsh
+        run: cargo build --locked -p sandbox-gateway --bin sandbox-gateway
+
+      - name: Build CLI (manager)
+        shell: pwsh
+        run: cargo build --locked -p sandbox-cli --no-default-features --features manager --bin sandbox-manager-cli
+
+      - name: Build CLI (runtime)
+        shell: pwsh
+        run: cargo build --locked -p sandbox-cli --no-default-features --features runtime --bin sandbox-runtime-cli
+
+      - name: Build CLI (observability)
+        shell: pwsh
+        run: cargo build --locked -p sandbox-cli --no-default-features --features observability --bin sandbox-observability-cli
+
+      - name: Build MCP
+        shell: pwsh
+        run: cargo build --locked -p sandbox-mcp --bin sandbox-mcp
+
+      - name: Test
+        shell: pwsh
+        run: cargo test --locked -p sandbox-gateway -p sandbox-cli -p sandbox-mcp -p sandbox-manager -p sandbox-provider-docker -p sandbox-operation-client -p sandbox-operation-contract -p sandbox-operation-catalog -p sandbox-config -p sandbox-protocol -p sandbox-runtime-layerstack
+
+      - name: Clippy
+        shell: pwsh
+        run: cargo clippy --locked --all-targets -p sandbox-gateway -p sandbox-cli -p sandbox-mcp -p sandbox-manager -p sandbox-provider-docker -p sandbox-operation-client -p sandbox-operation-contract -p sandbox-operation-catalog -p sandbox-config -p sandbox-protocol -p sandbox-runtime-layerstack
+
+      - name: Format check
+        shell: pwsh
+        run: cargo fmt --check

--- a/crates/sandbox-gateway/Cargo.toml
+++ b/crates/sandbox-gateway/Cargo.toml
@@ -11,7 +11,6 @@ name = "sandbox-gateway"
 path = "src/gateway/main.rs"
 
 [dependencies]
-nix = { workspace = true, features = ["process", "signal"] }
 sandbox-config.workspace = true
 sandbox-operation-contract.workspace = true
 sandbox-manager.workspace = true
@@ -23,6 +22,9 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 uuid.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+nix = { workspace = true, features = ["process", "signal"] }
 
 [lints]
 workspace = true

--- a/crates/sandbox-manager/tests/manager_export.rs
+++ b/crates/sandbox-manager/tests/manager_export.rs
@@ -435,6 +435,7 @@ fn every_catalog_spec_has_a_dispatcher() {
 
 // ------------------------------------------------------------- dir apply
 
+#[cfg(unix)]
 #[test]
 fn dir_apply_reproduces_winners_deletions_and_opaque_clears() {
     let env = env("dir-apply");
@@ -650,6 +651,7 @@ fn empty_delta_applies_as_a_clean_no_op() {
 
 // MED-06 twin: a symlink at a directory position is replaced, never
 // followed — its old target directory stays untouched.
+#[cfg(unix)]
 #[test]
 fn directory_winner_replaces_a_dest_symlink_without_following_it() {
     let env = env("symlink-replace");

--- a/crates/sandbox-manager/tests/manager_export.rs
+++ b/crates/sandbox-manager/tests/manager_export.rs
@@ -1,3 +1,5 @@
+#![cfg(unix)]
+
 //! Manager export surface: catalog + SPECS↔OPERATIONS parity (spec H6),
 //! the forward loop against a fake AND a hostile daemon, apply semantics
 //! (winners, deletions, opaque clears, dotfile-under-opaque ordering — spec
@@ -435,7 +437,6 @@ fn every_catalog_spec_has_a_dispatcher() {
 
 // ------------------------------------------------------------- dir apply
 
-#[cfg(unix)]
 #[test]
 fn dir_apply_reproduces_winners_deletions_and_opaque_clears() {
     let env = env("dir-apply");
@@ -651,7 +652,6 @@ fn empty_delta_applies_as_a_clean_no_op() {
 
 // MED-06 twin: a symlink at a directory position is replaced, never
 // followed — its old target directory stays untouched.
-#[cfg(unix)]
 #[test]
 fn directory_winner_replaces_a_dest_symlink_without_following_it() {
     let env = env("symlink-replace");

--- a/crates/sandbox-manager/tests/manager_router.rs
+++ b/crates/sandbox-manager/tests/manager_router.rs
@@ -12,6 +12,7 @@ use sandbox_manager::{
 };
 use sandbox_operation_catalog::{
     internal,
+    #[cfg(unix)]
     manager::EXPORT_CHANGES_SPEC,
     observability::{CGROUP_SPEC, DAEMON_SPEC, SNAPSHOT_SPEC},
     routes,
@@ -1073,6 +1074,7 @@ async fn manager_router_forwards_every_sandbox_observability_route() {
         .all(|(_, _, scope)| scope == &OperationScope::sandbox("sbox-1")));
 }
 
+#[cfg(unix)]
 #[tokio::test]
 async fn manager_router_rejects_internal_routes_while_public_export_uses_direct_daemon_port() {
     let (router, daemon_client) = ready_router();


### PR DESCRIPTION
Completes Windows x64 host support started in #6 (named-pipe gateway):

- Gate the unix-only 
ix dependency to [target.'cfg(unix)'.dependencies] in the sandbox-gateway manifest
- Gate unix-only export tests in sandbox-manager behind #[cfg(unix)] so cargo test -p sandbox-manager compiles on Windows
- Add a CI Windows amd64 workflow (build gateway/CLI/MCP, test 11 host crates, clippy --all-targets, fmt --check) on windows-2022

The daemon stays cross-compiled to Linux musl per the documented Windows host-only model.