### PR TITLE
fix(windows): repair cfg(unix) import placement and formatting in manager tests

### DIFF
--- a/crates/sandbox-manager/tests/manager_router.rs
+++ b/crates/sandbox-manager/tests/manager_router.rs
@@ -20,14 +20,14 @@ use sandbox_operation_catalog::{
         PUBLISH_WORKSPACE_SESSION_SPEC, READ_LINES_SPEC, WRITE_STDIN_SPEC,
     },
 };
-#[cfg(unix)]
-use sandbox_operation_catalog::manager::EXPORT_CHANGES_SPEC;
-
 use sandbox_operation_contract::{
     error, OperationExecutionOwner, OperationRequest, OperationResponse, OperationScope,
     OperationScopeKind, OperationVisibility,
 };
 use serde_json::{json, Value};
+
+#[cfg(unix)]
+use sandbox_operation_catalog::manager::EXPORT_CHANGES_SPEC;
 
 struct FakeRuntime {
     counters_available: bool,

--- a/crates/sandbox-manager/tests/manager_router.rs
+++ b/crates/sandbox-manager/tests/manager_router.rs
@@ -12,8 +12,6 @@ use sandbox_manager::{
 };
 use sandbox_operation_catalog::{
     internal,
-    #[cfg(unix)]
-    manager::EXPORT_CHANGES_SPEC,
     observability::{CGROUP_SPEC, DAEMON_SPEC, SNAPSHOT_SPEC},
     routes,
     runtime::{
@@ -22,6 +20,8 @@ use sandbox_operation_catalog::{
         PUBLISH_WORKSPACE_SESSION_SPEC, READ_LINES_SPEC, WRITE_STDIN_SPEC,
     },
 };
+#[cfg(unix)]
+use sandbox_operation_catalog::manager::EXPORT_CHANGES_SPEC;
 use sandbox_operation_contract::{
     error, OperationExecutionOwner, OperationRequest, OperationResponse, OperationScope,
     OperationScopeKind, OperationVisibility,

--- a/crates/sandbox-manager/tests/manager_router.rs
+++ b/crates/sandbox-manager/tests/manager_router.rs
@@ -22,6 +22,7 @@ use sandbox_operation_catalog::{
 };
 #[cfg(unix)]
 use sandbox_operation_catalog::manager::EXPORT_CHANGES_SPEC;
+
 use sandbox_operation_contract::{
     error, OperationExecutionOwner, OperationRequest, OperationResponse, OperationScope,
     OperationScopeKind, OperationVisibility,


### PR DESCRIPTION
PR #7 was merged with an intermediate revision whose manager_router.rs placed #[cfg(unix)] on a path item inside a group use block - a compile error on every target (the Windows CI run for that revision failed at build time).

This follow-up carries the verified fix from the fork's green CI run (305e0ab2a):

- Split manager::EXPORT_CHANGES_SPEC into its own #[cfg(unix)] use statement (a group-use path item cannot carry an attribute)
- Gate the direct-daemon-port export test behind #[cfg(unix)] (export apply is Unix-only)
- Place the cfg-gated import after plain use statements to satisfy rustfmt

CI on whp233/ephemeral-sandbox is green (build / test / clippy / fmt).